### PR TITLE
fix(format): mirror bwa_escape and free rg_line in sam_write_rg_line

### DIFF
--- a/format.c
+++ b/format.c
@@ -56,6 +56,8 @@ static char *mb_escape(char *s)
 		if (*p == '\\') {
 			++p;
 			if (*p == 't') *q++ = '\t';
+			else if (*p == 'n') *q++ = '\n';
+			else if (*p == 'r') *q++ = '\r';
 			else if (*p == '\\') *q++ = '\\';
 		} else *q++ = *p;
 	}
@@ -91,6 +93,7 @@ static int sam_write_rg_line(kstring_t *str, const char *s)
 	for (q = p, r = mb_rg_id; *q && *q != '\t' && *q != '\n'; ++q)
 		*r++ = *q;
 	kom_sprintf_lite(str, "%s\n", rg_line);
+	free(rg_line);
 	return 0;
 
 err_set_rg:


### PR DESCRIPTION
Two small fixes in `format.c`:

1. `mb_escape()` now decodes `\n` and `\r` in addition to `\t` and `\\`,
   matching `bwa_escape` in bwa (`bwa.c`). With this, `-R` strings that
   embed escaped newlines round-trip through the SAM header the same
   way they do in bwa.

2. `sam_write_rg_line()` was leaking `rg_line` on the success path:
   `kom_strdup` allocated, but only the error branch freed via
   `goto err_set_rg`. The success branch returned 0 without `free`.
   This adds the missing free before `return 0`.

Smoke test (`test/chrM-human.fa.gz` + `test/chrM-read_1.fa.gz` from this
tree, `minibwa map -a -R '@RG\tID:foo\tSM:bar'`):

- `@RG  ID:foo  SM:bar` lands in the header; `RG:Z:foo` on all 1006
  records.
- Error paths (no `@RG` prefix, missing ID, literal tab) still emit
  `[ERROR] ...` and abort with non-zero exit.

Marked draft pending review.