### PR TITLE
build: honor user-supplied LDFLAGS in minibwa link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CXX=		g++
 CFLAGS=		-std=c99 -g -Wall -O3
 CXXFLAGS=	$(CFLAGS)
 CPPFLAGS=
+LDFLAGS=
 INCLUDES=
 LOBJS=		kommon.o kalloc.o bwt.o l2bit.o options.o seed.o map-algo.o lchain.o align.o pe.o cs.o format.o \
 			ksw2_extz2_sse.o ksw2_extd2_sse.o ksw2_ll_sse.o
@@ -15,7 +16,8 @@ omp=		$(shell printf '\043include <omp.h>\nint main(){return 0;}' | $(CC) -x c -
 
 ifneq ($(asan),)
 	CFLAGS+=-fsanitize=address
-	LIBS+=-fsanitize=address -ldl
+	LDFLAGS+=-fsanitize=address
+	LIBS+=-ldl
 endif
 
 ifeq ($(omp),1)
@@ -53,7 +55,7 @@ libminibwa.a:$(LOBJS)
 		$(AR) -csru $@ $(LOBJS)
 
 minibwa:libminibwa.a $(MALLOC_O) $(AOBJS) main.o
-		$(CC) $(CFLAGS) $(MALLOC_O) $(AOBJS) main.o -o $@ -L. -lminibwa $(LIBS)
+		$(CC) $(CFLAGS) $(LDFLAGS) $(MALLOC_O) $(AOBJS) main.o -o $@ -L. -lminibwa $(LIBS)
 
 clean:
 		rm -fr *.o a.out $(PROG) *~ *.a *.dSYM


### PR DESCRIPTION
Adds an `LDFLAGS=` slot in the Makefile and threads it into the final `minibwa` link line, so users can pass linker flags via `make LDFLAGS="-Wl,-dead_strip"`, `make LDFLAGS="-static"`, etc. Today there's no way to inject linker-only flags without monkey-patching the recipe.

Side-effect: moved `-fsanitize=address` from `LIBS` to `LDFLAGS` in the `asan=` branch — same end result on the link line, just filed under the right variable. `-ldl` stays in `LIBS` since it is a library, not a linker flag.

Smoke test:

```
make clean && make -j4                              # default, OK
make clean && make -j4 LDFLAGS="-Wl,-dead_strip"    # OK; binary 541592 -> 432408 B,
                                                    # confirming -dead_strip reached the linker
make clean && asan=1 make -j4                       # asan branch still OK
```