### PR TITLE
cli: support --help on every subcommand

### DIFF
--- a/fastmap.c
+++ b/fastmap.c
@@ -70,6 +70,18 @@ static void process_batch(const mb_idx_t *idx, int32_t n, batch_seq1_t *t, int32
 	}
 }
 
+static int usage_fastmap(FILE *fp, int min_len, int min_occ, int max_size_out, int max_seq)
+{
+	fprintf(fp, "Usage: minibwa fastmap [options] <idx-prefix> <in.fq>\n");
+	fprintf(fp, "Options:\n");
+	fprintf(fp, "  -l INT     min seed length [%d]\n", min_len);
+	fprintf(fp, "  -s INT     min interval size [%d]\n", min_occ);
+	fprintf(fp, "  -w INT     max interval size to output coordinates [%d]\n", max_size_out);
+	fprintf(fp, "  -b INT     batch size [%d]\n", max_seq);
+	fprintf(fp, "  --help     print this help message\n");
+	return fp == stdout? 0 : 1;
+}
+
 int main_fastmap(int argc, char *argv[])
 {
 	mb_idx_t *idx;
@@ -83,23 +95,20 @@ int main_fastmap(int argc, char *argv[])
 	kstring_t out = {0};
 	int32_t n_seq = 0;
 	batch_seq1_t *seq = 0;
+	static ko_longopt_t long_opts[] = {
+		{ "help", ko_no_argument, 901 },
+		{ 0, 0, 0 }
+	};
 
-	while ((c = ketopt(&o, argc, argv, 1, "l:s:w:b:", 0)) >= 0) {
+	while ((c = ketopt(&o, argc, argv, 1, "l:s:w:b:", long_opts)) >= 0) {
 		if (c == 'l') min_len = atoi(o.arg);
 		else if (c == 's') min_occ = atoi(o.arg);
 		else if (c == 'w') max_size_out = atoi(o.arg);
 		else if (c == 'b') max_seq = atoi(o.arg);
+		else if (c == 901) return usage_fastmap(stdout, min_len, min_occ, max_size_out, max_seq);
 	}
 
-	if (argc - o.ind < 2) {
-		fprintf(stderr, "Usage: minibwa fastmap [options] <idx-prefix> <in.fq>\n");
-		fprintf(stderr, "Options:\n");
-		fprintf(stderr, "  -l INT     min seed length [%d]\n", min_len);
-		fprintf(stderr, "  -s INT     min interval size [%d]\n", min_occ);
-		fprintf(stderr, "  -w INT     max interval size to output coordinates [%d]\n", max_size_out);
-		fprintf(stderr, "  -b INT     batch size [%d]\n", max_seq);
-		return 1;
-	}
+	if (argc - o.ind < 2) return usage_fastmap(stderr, min_len, min_occ, max_size_out, max_seq);
 
 	idx = mb_idx_load(argv[o.ind]);
 	bwt = idx->bwt;

--- a/index.c
+++ b/index.c
@@ -53,6 +53,17 @@ mb_bwt_t *mb_bwt_libsais(const l2b_t *l2b, int sa_bit, int both_strand, int n_th
 	return bwt;
 }
 
+static int usage_fa2bit(FILE *fp, uint64_t seed)
+{
+	fprintf(fp, "Usage: minibwa fa2bit [options] <in.fa> <out.l2b>\n");
+	fprintf(fp, "Options:\n");
+	fprintf(fp, "  -s INT    random seed [%lu]\n", (unsigned long)seed);
+	fprintf(fp, "  -p        output the BWA pac format\n");
+	fprintf(fp, "  -2        output both strands (effective with -p)\n");
+	fprintf(fp, "  --help    print this help message\n");
+	return fp == stdout? 0 : 1;
+}
+
 int main_fa2bit(int argc, char *argv[])
 {
 	l2b_t *l2b;
@@ -60,19 +71,17 @@ int main_fa2bit(int argc, char *argv[])
 	uint64_t seed = 11;
 	ketopt_t o = KETOPT_INIT;
 	int c;
-	while ((c = ketopt(&o, argc, argv, 1, "s:p2", 0)) >= 0) {
+	static ko_longopt_t long_opts[] = {
+		{ "help", ko_no_argument, 901 },
+		{ 0, 0, 0 }
+	};
+	while ((c = ketopt(&o, argc, argv, 1, "s:p2", long_opts)) >= 0) {
 		if (c == 's') seed = atol(o.arg);
 		else if (c == 'p') out_pac = 1;
 		else if (c == '2') both_strand = 1;
+		else if (c == 901) return usage_fa2bit(stdout, seed);
 	}
-	if (argc - o.ind < 2) {
-		fprintf(stderr, "Usage: minibwa fa2bit [options] <in.fa> <out.l2b>\n");
-		fprintf(stderr, "Options:\n");
-		fprintf(stderr, "  -s INT    random seed [%lu]\n", (unsigned long)seed);
-		fprintf(stderr, "  -p        output the BWA pac format\n");
-		fprintf(stderr, "  -2        output both strands (effective with -p)\n");
-		return 1;
-	}
+	if (argc - o.ind < 2) return usage_fa2bit(stderr, seed);
 	l2b = l2b_import(argv[o.ind], seed);
 	if (out_pac)
 		l2b_save_pac(argv[o.ind+1], l2b, both_strand);
@@ -82,39 +91,73 @@ int main_fa2bit(int argc, char *argv[])
 	return 0;
 }
 
+#ifdef USE_GPL
+static int usage_genraw(FILE *fp)
+{
+	fprintf(fp, "Usage: minibwa genraw [options] <in.pac> <out.raw-bwt>\n");
+	fprintf(fp, "Options:\n");
+	fprintf(fp, "  -b NUM      block size [10m]\n");
+	fprintf(fp, "  --help      print this help message\n");
+	return fp == stdout? 0 : 1;
+}
+#endif
+
 int main_genraw(int argc, char *argv[])
 {
 #ifdef USE_GPL
 	ketopt_t o = KETOPT_INIT;
 	int c, block_size = 10000000;
-	while ((c = ketopt(&o, argc, argv, 1, "b:", 0)) >= 0) {
+	static ko_longopt_t long_opts[] = {
+		{ "help", ko_no_argument, 901 },
+		{ 0, 0, 0 }
+	};
+	while ((c = ketopt(&o, argc, argv, 1, "b:", long_opts)) >= 0) {
 		if (c == 'b') block_size = kom_parse_num(o.arg, 0);
+		else if (c == 901) return usage_genraw(stdout);
 	}
-	if (argc - o.ind < 2) {
-		fprintf(stderr, "Usage: minibwa genraw [options] <in.pac> <out.raw-bwt>\n");
-		fprintf(stderr, "Options:\n");
-		fprintf(stderr, "  -b NUM      block size [10m]\n");
-		return 1;
-	}
+	if (argc - o.ind < 2) return usage_genraw(stderr);
 	mb_bwtgen(argv[o.ind], argv[o.ind+1], block_size);
 	return 0;
 #else
+	(void)argc; (void)argv;
 	if (kom_verbose >= 1) fprintf(stderr, "ERROR: genraw not compiled as it depends on GPL'd code\n");
 	return 1;
 #endif
 }
 
+static int usage_raw2bwt(FILE *fp)
+{
+	fprintf(fp, "Usage: minibwa raw2bwt <raw.bwt> <recode.bwt>\n");
+	fprintf(fp, "Options:\n");
+	fprintf(fp, "  --help    print this help message\n");
+	return fp == stdout? 0 : 1;
+}
+
 int main_raw2bwt(int argc, char *argv[])
 {
 	mb_bwt_t *bwt;
-	if (argc < 3) {
-		printf("Usage: minibwa raw2bwt <raw.bwt> <recode.bwt>\n");
-		return 1;
-	}
+	int i;
+	for (i = 1; i < argc; ++i)
+		if (strcmp(argv[i], "--help") == 0) return usage_raw2bwt(stdout);
+	if (argc < 3) return usage_raw2bwt(stderr);
 	bwt = mb_bwt_load_raw(argv[1]);
 	mb_bwt_save(argv[2], bwt);
 	mb_bwt_destroy(bwt);
 	return 0;
+}
+
+static int usage_genbwt(FILE *fp, int sa_bit, int n_thread)
+{
+	(void)n_thread;
+	fprintf(fp, "Usage: minibwa genbwt [options] <in.l2b> <out.bwt>\n");
+	fprintf(fp, "Options:\n");
+	fprintf(fp, "  -u INT      SA sample rate at 1/(1<<INT) [%d]\n", sa_bit);
+	fprintf(fp, "  -1          forward strand only\n");
+#ifdef LIBSAIS_OPENMP
+	fprintf(fp, "  -t INT      number of threads [%d]\n", n_thread);
+#endif
+	fprintf(fp, "  --help      print this help message\n");
+	return fp == stdout? 0 : 1;
 }
 
 int main_genbwt(int argc, char *argv[])
@@ -123,21 +166,17 @@ int main_genbwt(int argc, char *argv[])
 	int c, n_thread = 4, both_strand = 1, sa_bit = 4;
 	mb_bwt_t *bwt;
 	l2b_t *l2b;
-	while ((c = ketopt(&o, argc, argv, 1, "1u:t:", 0)) >= 0) {
+	static ko_longopt_t long_opts[] = {
+		{ "help", ko_no_argument, 901 },
+		{ 0, 0, 0 }
+	};
+	while ((c = ketopt(&o, argc, argv, 1, "1u:t:", long_opts)) >= 0) {
 		if (c == 't') n_thread = atoi(o.arg);
 		else if (c == '1') both_strand = 0;
 		else if (c == 'u') sa_bit = atoi(o.arg);
+		else if (c == 901) return usage_genbwt(stdout, sa_bit, n_thread);
 	}
-	if (argc - o.ind < 2) {
-		fprintf(stderr, "Usage: minibwa genbwt [options] <in.l2b> <out.bwt>\n");
-		fprintf(stderr, "Options:\n");
-		fprintf(stderr, "  -u INT      SA sample rate at 1/(1<<INT) [%d]\n", sa_bit);
-		fprintf(stderr, "  -1          forward strand only\n");
-#ifdef LIBSAIS_OPENMP
-		fprintf(stderr, "  -t INT      number of threads [%d]\n", n_thread);
-#endif
-		return 1;
-	}
+	if (argc - o.ind < 2) return usage_genbwt(stderr, sa_bit, n_thread);
 	l2b = l2b_load(argv[o.ind]);
 	kom_assert(l2b, "failed to open the input file.");
 	bwt = mb_bwt_libsais(l2b, both_strand, 5, n_thread);
@@ -147,27 +186,52 @@ int main_genbwt(int argc, char *argv[])
 	return 0;
 }
 
+static int usage_gensa(FILE *fp, int sa_bit)
+{
+	fprintf(fp, "Usage: minibwa gensa [options] <in.bwt> <out.bwt>\n");
+	fprintf(fp, "Options:\n");
+	fprintf(fp, "  -u INT    sample rate at 1/(1<<INT) [%d]\n", sa_bit);
+	fprintf(fp, "  -r        input BWT in the raw BWA format\n");
+	fprintf(fp, "  --help    print this help message\n");
+	return fp == stdout? 0 : 1;
+}
+
 int main_gensa(int argc, char *argv[])
 {
 	mb_bwt_t *bwt;
 	int c, sa_bit = 4, is_raw = 0;
 	ketopt_t o = KETOPT_INIT;
-	while ((c = ketopt(&o, argc, argv, 1, "ru:", 0)) >= 0) {
+	static ko_longopt_t long_opts[] = {
+		{ "help", ko_no_argument, 901 },
+		{ 0, 0, 0 }
+	};
+	while ((c = ketopt(&o, argc, argv, 1, "ru:", long_opts)) >= 0) {
 		if (c == 'u') sa_bit = atoi(o.arg);
 		else if (c == 'r') is_raw = 1;
+		else if (c == 901) return usage_gensa(stdout, sa_bit);
 	}
-	if (argc - o.ind < 2) {
-		fprintf(stderr, "Usage: minibwa gensa [options] <in.bwt> <out.bwt>\n");
-		fprintf(stderr, "Options:\n");
-		fprintf(stderr, "  -u INT    sample rate at 1/(1<<INT) [%d]\n", sa_bit);
-		fprintf(stderr, "  -r        input BWT in the raw BWA format\n");
-		return 1;
-	}
+	if (argc - o.ind < 2) return usage_gensa(stderr, sa_bit);
 	bwt = is_raw? mb_bwt_load_raw(argv[o.ind]) : mb_bwt_load(argv[o.ind]);
 	mb_bwt_gen_sa(bwt, sa_bit);
 	mb_bwt_save(argv[o.ind+1], bwt);
 	mb_bwt_destroy(bwt);
 	return 0;
+}
+
+static int usage_index(FILE *fp, uint64_t seed, int sa_bit, int n_thread)
+{
+	(void)n_thread;
+	fprintf(fp, "Usage: minibwa index [options] <in.fasta> [out.prefix]\n");
+	fprintf(fp, "Options:\n");
+	fprintf(fp, "  -s INT    random seed for amibiguous bases [%ld]\n", (unsigned long)seed);
+	fprintf(fp, "  -u INT    SA sample rate at 1/(1<<INT) [%d]\n", sa_bit);
+	fprintf(fp, "  -l        low-memory GPL'd algorithm for BWT construction\n");
+	fprintf(fp, "  -b NUM    block size (effective with -l) [10m]\n");
+#ifdef LIBSAIS_OPENMP
+	fprintf(fp, "  -t INT    number of threads (effective w/o -l) [%d]\n", n_thread);
+#endif
+	fprintf(fp, "  --help    print this help message\n");
+	return fp == stdout? 0 : 1;
 }
 
 int main_index(int argc, char *argv[])
@@ -179,26 +243,20 @@ int main_index(int argc, char *argv[])
 	char *prefix, *fn_l2b, *fn_bwt;
 	l2b_t *l2b;
 	mb_bwt_t *bwt;
+	static ko_longopt_t long_opts[] = {
+		{ "help", ko_no_argument, 901 },
+		{ 0, 0, 0 }
+	};
 
-	while ((c = ketopt(&o, argc, argv, 1, "ls:u:b:t:", 0)) >= 0) {
+	while ((c = ketopt(&o, argc, argv, 1, "ls:u:b:t:", long_opts)) >= 0) {
 		if (c == 't') n_thread = atoi(o.arg);
 		else if (c == 'l') low_mem = 1;
 		else if (c == 'b') block_size = kom_parse_num(o.arg, 0);
 		else if (c == 'u') sa_bit = atoi(o.arg);
 		else if (c == 's') seed = atol(o.arg);
+		else if (c == 901) return usage_index(stdout, seed, sa_bit, n_thread);
 	}
-	if (argc - o.ind == 0) {
-		fprintf(stderr, "Usage: minibwa index [options] <in.fasta> [out.prefix]\n");
-		fprintf(stderr, "Options:\n");
-		fprintf(stderr, "  -s INT    random seed for amibiguous bases [%ld]\n", (unsigned long)seed);
-		fprintf(stderr, "  -u INT    SA sample rate at 1/(1<<INT) [%d]\n", sa_bit);
-		fprintf(stderr, "  -l        low-memory GPL'd algorithm for BWT construction\n");
-		fprintf(stderr, "  -b NUM    block size (effective with -l) [10m]\n");
-#ifdef LIBSAIS_OPENMP
-		fprintf(stderr, "  -t INT    number of threads (effective w/o -l) [%d]\n", n_thread);
-#endif
-		return 1;
-	}
+	if (argc - o.ind == 0) return usage_index(stderr, seed, sa_bit, n_thread);
 
 	prefix = o.ind + 1 < argc? argv[o.ind+1] : argv[o.ind];
 	fn_l2b = kom_calloc(char, strlen(prefix) + 5);

--- a/main.c
+++ b/main.c
@@ -38,10 +38,13 @@ static int usage(FILE *fp, int is_long)
 		fprintf(fp, "  Debugging:\n");
 		fprintf(fp, "    bench      performance evaluation\n");
 		fprintf(fp, "    fastmap    test seeding strategies\n");
+		fprintf(fp, "  Help:\n");
+		fprintf(fp, "    --help     print this help message\n");
 	} else {
 		fprintf(fp, "  index      index reference FASTA\n");
 		fprintf(fp, "  map        read alignment\n");
 		fprintf(fp, "  version    print the version number\n");
+		fprintf(fp, "  --help     print this help message\n");
 	}
 	return fp == stdout? 0 : 1;
 }
@@ -82,6 +85,19 @@ int main(int argc, char *argv[])
 
 typedef enum { MB_BENCH_2A, MB_BENCH_SA, MB_BENCH_MSA } mb_bench_type_t;
 
+static int usage_bench(FILE *fp, int intv)
+{
+	fprintf(fp, "Usage: minibwa bench [options] <in.mbw>\n");
+	fprintf(fp, "Options:\n");
+	fprintf(fp, "  -b STR         type: 2a, sa or msa [2a]\n");
+	fprintf(fp, "  -n NUM         number of data points [1m]\n");
+	fprintf(fp, "  -v INT         interval size for msa [%d]\n", intv);
+	fprintf(fp, "  -p             print results for each data point\n");
+	fprintf(fp, "  -1             use unbatched sa for msa\n");
+	fprintf(fp, "  --help         print this help message\n");
+	return fp == stdout? 0 : 1;
+}
+
 int main_bench(int argc, char *argv[])
 {
 	mb_bench_type_t type = MB_BENCH_2A;
@@ -91,8 +107,12 @@ int main_bench(int argc, char *argv[])
 	mb_bwt_t *bwt;
 	ketopt_t o = KETOPT_INIT;
 	double t;
+	static ko_longopt_t long_opts[] = {
+		{ "help", ko_no_argument, 901 },
+		{ 0, 0, 0 }
+	};
 
-	while ((c = ketopt(&o, argc, argv, 1, "pn:b:v:1", 0)) >= 0) {
+	while ((c = ketopt(&o, argc, argv, 1, "pn:b:v:1", long_opts)) >= 0) {
 		if (c == 'n') n = kom_parse_num(o.arg, 0);
 		else if (c == 'p') print_val = 1;
 		else if (c == '1') use_single = 1;
@@ -103,17 +123,9 @@ int main_bench(int argc, char *argv[])
 			else if (strcmp(o.arg, "msa") == 0) type = MB_BENCH_MSA;
 			else kom_assert(0, "unknown type");
 		}
+		else if (c == 901) return usage_bench(stdout, intv);
 	}
-	if (argc - o.ind < 1) {
-		fprintf(stderr, "Usage: minibwa bench [options] <in.mbw>\n");
-		fprintf(stderr, "Options:\n");
-		fprintf(stderr, "  -b STR         type: 2a, sa or msa [2a]\n");
-		fprintf(stderr, "  -n NUM         number of data points [1m]\n");
-		fprintf(stderr, "  -v INT         interval size for msa [%d]\n", intv);
-		fprintf(stderr, "  -p             print results for each data point\n");
-		fprintf(stderr, "  -1             use unbatched sa for msa\n");
-		return 1;
-	}
+	if (argc - o.ind < 1) return usage_bench(stderr, intv);
 
 	bwt = mb_bwt_load(argv[o.ind]);
 	t = kom_cputime();

--- a/main.c
+++ b/main.c
@@ -44,7 +44,6 @@ static int usage(FILE *fp, int is_long)
 		fprintf(fp, "  index      index reference FASTA\n");
 		fprintf(fp, "  map        read alignment\n");
 		fprintf(fp, "  version    print the version number\n");
-		fprintf(fp, "  --help     print this help message\n");
 	}
 	return fp == stdout? 0 : 1;
 }

--- a/map-main.c
+++ b/map-main.c
@@ -290,6 +290,7 @@ static ko_longopt_t long_options[] = {
 	{ "dbg-aln-pe",   ko_no_argument,       605 },
 	{ "dbg-an-pos",   ko_no_argument,       606 }, // anchor position
 	{ "version",      ko_no_argument,       901 },
+	{ "help",         ko_no_argument,       902 },
 	{ 0, 0, 0 }
 };
 
@@ -332,6 +333,7 @@ static int usage(FILE *fp, const mb_opt_t *opt)
 	fprintf(fp, "    -Y               use soft clipping for supplementary alignments\n");
 	fprintf(fp, "    -K NUM1[,NUM2]   process NUM1-NUM2 bp of query sequences in a batch [100m,1g]\n");
 	fprintf(fp, "    --version        print version number\n");
+	fprintf(fp, "    --help           print this help message\n");
 	return fp == stdout? 0 : 1;
 }
 
@@ -449,6 +451,8 @@ int main_map(int argc, char *argv[])
 		} else if (c == 901) { // --version
 			puts(MB_VERSION);
 			exit(0);
+		} else if (c == 902) { // --help
+			return usage(stdout, &mo);
 		}
 	}
 	if (argc - o.ind < 2)


### PR DESCRIPTION
Each `minibwa <subcmd>` now accepts `--help`, prints its own usage to stdout, and exits 0. Today only top-level `minibwa --help` works; on subcommands it falls through to the no-args usage path on stderr with exit 1, which is awkward for shells and wrappers that probe `--help` to detect a tool.

Pattern is mechanical: each subcommand's inline `fprintf(stderr, "Usage: ...")` block is hoisted into `static int usage_<subcmd>(FILE *fp, ...)` with `return fp == stdout? 0 : 1;`, and `{"help", ko_no_argument, 901}` is added to that subcommand's `ko_longopt_t` array (902 in `map-main.c` since 901 is already taken by `--version` there). `raw2bwt` doesn't use ketopt, so it gets a small manual `--help` scan over `argv`.

Also added a `--help` line to the top-level usage text for discoverability, and unified all the new help text to `print this help message` (matches the brevity of the existing `--version    print version number`).

Subcommands wired: `index`, `map` / `mem`, `fa2bit`, `genraw`, `raw2bwt`, `genbwt`, `gensa`, `bench`, `fastmap` (9 total).

Verified per subcommand: `./minibwa <subcmd> --help` prints to stdout and exits 0; `./minibwa <subcmd>` with no args still prints to stderr and exits 1; other options/error paths unchanged. `make -j4` clean, no new warnings.