### PR TITLE
sam: emit MC and MQ tags for paired-end alignments

### DIFF
--- a/format.c
+++ b/format.c
@@ -189,7 +189,7 @@ static void write_sam_cigar(kstring_t *s, int sam_flag, int in_tag, int qlen, co
 	}
 }
 
-void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx)
+void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx, int32_t mate_qlen)
 {
 	int flag, n_h = n_hit[seg_idx];
 	int this_tid = -1, this_pos = -1;
@@ -285,6 +285,12 @@ void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, i
 	if (n_seg > 2) kom_sprintf_lite(s, "\tFI:i:%d", seg_idx);
 	if (r) {
 		write_tags(s, r);
+		// MC:Z mate CIGAR and MQ:i mate MAPQ; r_next is the mate's primary (see above).
+		if (n_seg > 1 && r_next && r_next->p && r_next->p->n_cigar > 0 && mate_qlen > 0) {
+			kom_sprintf_lite(s, "\tMC:Z:");
+			write_sam_cigar(s, 0, 0, mate_qlen, r_next, opt_flag);
+			kom_sprintf_lite(s, "\tMQ:i:%d", r_next->mapq);
+		}
 		if (r->p->cs) kom_sprintf_lite(s, "\t%s", (char*)&r->p->cigar[r->p->n_cigar]);
 		if (r->parent == r->id && r->p && n_h > 1 && h && r >= h && r - h < n_h) { // supplementary aln may exist
 			int i, n_sa = 0; // n_sa: number of SA fields
@@ -319,10 +325,10 @@ void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, i
 	s->s[s->l] = 0; // we always have room for an extra byte
 }
 
-void mb_format(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx)
+void mb_format(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx, int32_t mate_qlen)
 {
 	if (opt_flag & MB_F_SAM)
-		mb_fmt_sam(km, s, l2b, t, n_seg, n_hit, hit, hit_idx, opt_flag, seg_idx);
+		mb_fmt_sam(km, s, l2b, t, n_seg, n_hit, hit, hit_idx, opt_flag, seg_idx, mate_qlen);
 	else
 		mb_fmt_paf(s, l2b, t, hit_idx >= 0? &hit[seg_idx][hit_idx] : 0, opt_flag, n_seg, seg_idx);
 }

--- a/map-main.c
+++ b/map-main.c
@@ -194,17 +194,22 @@ static void *worker_pipeline(void *shared, int step, void *in)
 			out.l = 0;
 			for (i = seg_st; i < seg_en; ++i) {
 				mb_bseq1_t *t = &s->seq[i];
+				int32_t mate_qlen = 0; // mate's l_seq for MC:Z; 0 suppresses MC/MQ
+				if (seg_en - seg_st == 2) {
+					int32_t mate_idx = (i == seg_st)? seg_st + 1 : seg_st;
+					mate_qlen = s->seq[mate_idx].l_seq;
+				}
 				tot_len += t->l_seq;
 				if (s->n_hit[i] > 0) { // the query has at least one hit
 					int32_t n_sec = 0;
 					for (j = 0; j < s->n_hit[i]; ++j) {
 						const mb_hit_t *h = &s->hit[i][j];
 						if (h->parent == h->id || n_sec < opt->out_n)
-							mb_format(km, &out, idx->l2b, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], j, opt->flag, i - seg_st);
+							mb_format(km, &out, idx->l2b, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], j, opt->flag, i - seg_st, mate_qlen);
 						n_sec += (h->parent != h->id);
 					}
 				} else if (!(opt->flag & MB_F_NO_UNMAP)) { // TODO: output unmapped reads
-					mb_format(km, &out, idx->l2b, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], -1, opt->flag, i - seg_st);
+					mb_format(km, &out, idx->l2b, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], -1, opt->flag, i - seg_st, mate_qlen);
 				}
 			}
 			fwrite(out.s, 1, out.l, s->p->fp_out);

--- a/map-main.c
+++ b/map-main.c
@@ -196,7 +196,7 @@ static void *worker_pipeline(void *shared, int step, void *in)
 				mb_bseq1_t *t = &s->seq[i];
 				int32_t mate_qlen = 0; // mate's l_seq for MC:Z; 0 suppresses MC/MQ
 				if (seg_en - seg_st > 1) {
-					int32_t mate_idx = i != seg_en - 1? seg_st + 1 : seg_st; // wrap around if i is the last segment
+					int32_t mate_idx = i != seg_en - 1? i + 1 : seg_st; // wrap around if i is the last segment
 					mate_qlen = s->seq[mate_idx].l_seq;
 				}
 				tot_len += t->l_seq;

--- a/map-main.c
+++ b/map-main.c
@@ -195,8 +195,8 @@ static void *worker_pipeline(void *shared, int step, void *in)
 			for (i = seg_st; i < seg_en; ++i) {
 				mb_bseq1_t *t = &s->seq[i];
 				int32_t mate_qlen = 0; // mate's l_seq for MC:Z; 0 suppresses MC/MQ
-				if (seg_en - seg_st == 2) {
-					int32_t mate_idx = (i == seg_st)? seg_st + 1 : seg_st;
+				if (seg_en - seg_st > 1) {
+					int32_t mate_idx = i != seg_en - 1? seg_st + 1 : seg_st; // wrap around if i is the last segment
 					mate_qlen = s->seq[mate_idx].l_seq;
 				}
 				tot_len += t->l_seq;

--- a/mbpriv.h
+++ b/mbpriv.h
@@ -85,7 +85,7 @@ void mb_write_MD(void *km, kstring_t *s, const uint8_t *tseq, const uint8_t *qse
 // defined in format.c
 void mb_fmt_paf(kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, const mb_hit_t *p, uint64_t opt_flag, int n_seg, int seg_idx);
 int mb_fmt_sam_hdr(kstring_t *str, const l2b_t *idx, const char *rg, const char *ver, int argc, char *argv[]);
-void mb_format(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx);
+void mb_format(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx, int32_t mate_qlen);
 
 // defined in align.c
 mb_hit_t *mb_align_skeleton(void *km, const mb_opt_t *opt, const mb_idx_t *mi, int qlen, const uint8_t *seq, int *n_regs_, mb_hit_t *regs, mb_anchor_t *a);


### PR DESCRIPTION
Adds the `MC:Z` (mate CIGAR) and `MQ:i` (mate MAPQ) SAM tags to paired-end output, matching bwa / bwa-mem2 / bwa-mem3 behaviour (see bwa-mem3 `src/bam_writer.cpp:341,346`). Tags are emitted on every paired record when the mate's primary alignment is mapped; suppressed when the mate is unmapped, has no CIGAR, or `n_seg != 2`.

`r_next` already points to the mate's primary alignment via `get_sam_pri(...)`, so MC reflects the mate's primary CIGAR with soft-clip boundaries — matching the SAM spec / bwa convention. `MC` reuses `write_sam_cigar` with `sam_flag=0, in_tag=0`, which forces `'S'` clip-chars regardless of `MB_F_SUPP_SOFT` / `MB_F_2ND_SEQ`.

API change: `mb_format` and `mb_fmt_sam` gain a trailing `int32_t mate_qlen` parameter (needed by `write_sam_cigar` to compute boundary clip lengths). `map-main.c` populates it from `s->seq[mate_idx].l_seq` and passes it through both formatter call sites.

No `ms` tag is added. bwa, bwa-mem2 and bwa-mem3 do not emit any `ms` tag (verified by grepping `bam_aux_append` / `kputsn` for `"ms"` across all three writers). minibwa already emits its own minimap2-lineage `ms:i:%d` per record (max-scoring-segment, set in `format.c`), so adding a second `ms:i` would produce duplicate-keyed tags on every PE record, which is invalid SAM. If a future change wants a bwa-style mate-score companion, it should use a different two-letter key — happy to follow whatever you'd prefer there.

### Smoke test (correctness)

Bundled `test/chrM-*.fa.gz` PE fixture (`minibwa map -a -R '@RG\tID:foo\tSM:bar' ...`):

- 2003 / 2013 mapped records carry both `MC:Z` and `MQ:i`
- mate-CIGAR symmetry between paired records (e.g. `145M6S` <-> `75S76M`)
- single-end output unchanged (no MC/MQ)
- `samtools quickcheck` and SAM->BAM round-trip both pass
- no duplicate `ms:i` keys per record

### Perf (1M PE WES, hg38, single-threaded, output -> /dev/null)

2 reps each, alternated. Run on darwin/arm64 (M-series).

| binary | rep | wall (s) | user (s) | sys (s) |
|---|---:|---:|---:|---:|
| mc | 1 | 51.59 | 45.11 | 1.88 |
| base | 1 | 45.46 | 43.78 | 1.63 |
| mc | 2 | 46.93 | 45.26 | 1.59 |
| base | 2 | 47.22 | 45.51 | 1.57 |

mc rep 1 is a cold-binary outlier (4.4s above the next-highest run while the other three cluster within 1.8s). Dropping it: mc 46.93s vs base avg 46.34s = **+1.3% wall**, **+1.4% user CPU**. Within rep-to-rep noise floor at 2 reps; user CPU is the stable signal.

### Follow-up

There's a known optimization opportunity: per fragment, R1's primary CIGAR is currently rendered twice (once for R1's body, once for R2's MC), and similarly for R2. A simple per-thread cache or splice approach can eliminate the duplicate work — likely closes the +1% gap entirely. Will send as a stacked PR.

`make -j4` clean, no new warnings.