### PR TITLE
fix(ksw2): drop !zdropped gate on EXTZ_ONLY end_bonus backtrack

### DIFF
--- a/ksw2_extd2_sse.c
+++ b/ksw2_extd2_sse.c
@@ -371,7 +371,7 @@ void ksw_extd2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uin
 		int rev_cigar = !!(flag & KSW_EZ_REV_CIGAR);
 		if (!ez->zdropped && !(flag&KSW_EZ_EXTZ_ONLY)) {
 			ksw_backtrack(km, 1, rev_cigar, 0, (uint8_t*)p, off, off_end, n_col_*16, tlen-1, qlen-1, &ez->m_cigar, &ez->n_cigar, &ez->cigar);
-		} else if (!ez->zdropped && (flag&KSW_EZ_EXTZ_ONLY) && ez->mqe + end_bonus > (int)ez->max) {
+		} else if ((flag&KSW_EZ_EXTZ_ONLY) && ez->mqe + end_bonus > (int)ez->max) {
 			ez->reach_end = 1;
 			ksw_backtrack(km, 1, rev_cigar, 0, (uint8_t*)p, off, off_end, n_col_*16, ez->mqe_t, qlen-1, &ez->m_cigar, &ez->n_cigar, &ez->cigar);
 		} else if (ez->max_t >= 0 && ez->max_q >= 0) {

--- a/ksw2_extz2_sse.c
+++ b/ksw2_extz2_sse.c
@@ -285,7 +285,7 @@ void ksw_extz2_sse(void *km, int qlen, const uint8_t *query, int tlen, const uin
 		int rev_cigar = !!(flag & KSW_EZ_REV_CIGAR);
 		if (!ez->zdropped && !(flag&KSW_EZ_EXTZ_ONLY)) {
 			ksw_backtrack(km, 1, rev_cigar, 0, (uint8_t*)p, off, off_end, n_col_*16, tlen-1, qlen-1, &ez->m_cigar, &ez->n_cigar, &ez->cigar);
-		} else if (!ez->zdropped && (flag&KSW_EZ_EXTZ_ONLY) && ez->mqe + end_bonus > (int)ez->max) {
+		} else if ((flag&KSW_EZ_EXTZ_ONLY) && ez->mqe + end_bonus > (int)ez->max) {
 			ez->reach_end = 1;
 			ksw_backtrack(km, 1, rev_cigar, 0, (uint8_t*)p, off, off_end, n_col_*16, ez->mqe_t, qlen-1, &ez->m_cigar, &ez->n_cigar, &ez->cigar);
 		} else if (ez->max_t >= 0 && ez->max_q >= 0) {


### PR DESCRIPTION
## Heads-up: forthcoming c2t / methylation PR

I have a follow-up PR adding bwameth-style C→T / G→A read projection to `--meth` (analogous to bwa-mem3's mode), which I'll send next. That work surfaced this bug — bisulfite-projected R2 collapses to a 2-letter A/T alphabet, which is the worst case for this gate. I'm submitting the ksw2 fix separately because it's an independent correctness issue that helps all minibwa users, not just bisulfite ones, and the methylation branch is larger and warrants its own discussion.

## Summary

In `ksw2_extz2_sse` and `ksw2_extd2_sse`'s backtrack section, the `EXTZ_ONLY` branch that sets `reach_end=1` and backtracks to `(mqe_t, qlen-1)` was gated on **both** `!ez->zdropped` AND `ez->mqe + end_bonus > ez->max`. The first gate is too conservative: when extension reaches q-end (`mqe` set in iteration `r1`) and z-drop fires LATER (iteration `r2 > r1`), the path to `(mqe_t, qlen-1)` was fully populated before z-drop and is the correct end-extension alignment. The post-mqe z-drop reflects the score landscape past q-end and is irrelevant to the q-end backtrack. The remaining `mqe + end_bonus > max` gate is sufficient to reject q-ends that aren't close to the global max.

## Symptom

Systematic 1–4 bp leading soft-clips on mate-rescued reads in `pe.c::mb_matesw_align`, where the calling code trims the alignment to `max_q + 1` whenever `ez->reach_end == 0`. Bites hardest on inputs whose score landscape is flat enough that z-drop reliably fires after `mqe` is set — bisulfite-projected reads (per the followup PR), homopolymer/AT-rich runs, and noisy reads in general.

## Impact (holodeck-simulated chr22, `minibwa map -t 8`)

R1 + R2 mapping rate unchanged at 100% across all tests. POS-exact is the rate at which R1/R2 alignments hit the truth coordinate exactly.

| dataset | wall (baseline → fix) | R1 / R2 POS-exact (baseline → fix) |
|---|---|---|
| Standard (chr22, 1×, 0.1–1% error, 169k pairs) | 1.21 s → 1.32 s | 98.768% / 98.768% → 98.777% / 98.777% |
| AT-rich target (chr22:16–17M, 30×, 100k pairs) | 0.74 s → 0.81 s | 98.084% / 98.034% → 98.085% / 98.046% |
| **High error (chr22, 1×, 2–10% error, 169k pairs)** | **2.27 s → 2.27 s** | **89.0% / 77.4% → 93.9% / 86.6%** |
| em-seq, rate=0.0, chr22 1M pairs (with followup) | 60.95 s → 58.84 s | 97.88% / **52.7% → 94.9%** |

The high-error case is the practical motivator for stock minibwa users: ~9 pp of R2 POS-exact recovered (≈15,700 reads correctly placed per 169k pairs). The standard-error and AT-rich rows confirm the fix is benign on inputs where the original gate happened to do the right thing — no regressions, only marginal wins. The em-seq row (using the followup methylation patches) is the worst-case demonstration: a 42 pp R2 POS-exact gain, almost entirely from removing leading soft-clips.

Wallclock unchanged across all datasets (within noise — the small dataset variance is ±10%, the large em-seq run is within 4%).

## Files

- `ksw2_extz2_sse.c:288` — drop `!ez->zdropped` (single-affine-gap)
- `ksw2_extd2_sse.c:374` — drop `!ez->zdropped` (dual-affine-gap)

Note: `mte` is tracked but never read in any backtrack branch — no symmetric bug.