### PR TITLE
perf(index): parallelize SA-to-BWT pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,3 +12,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: make -j$(nproc)
       - run: make -j$(nproc) -C api-test
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: brew install libomp
+      - run: make -j$(sysctl -n hw.ncpu)
+      - name: verify OpenMP (libomp) is linked
+        run: otool -L minibwa | grep -qi omp || { echo "libomp not linked; the macOS OpenMP build path is broken"; exit 1; }
+      - run: make -j$(sysctl -n hw.ncpu) -C api-test
+      - name: smoke parallel index build
+        run: |
+          gzip -dc test/chrM-human.fa.gz > chrM.fa
+          ./minibwa index -t4 chrM.fa

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ cs.o: mbpriv.h minibwa.h l2bit.h bwt.h kommon.h bseq.h kalloc.h
 fastmap.o: mbpriv.h minibwa.h l2bit.h bwt.h kommon.h bseq.h ketopt.h kseq.h
 fastmap.o: kalloc.h
 format.o: mbpriv.h minibwa.h l2bit.h bwt.h kommon.h bseq.h
-index.o: libsais64.h kommon.h ketopt.h mbpriv.h minibwa.h l2bit.h bwt.h
-index.o: bseq.h
+index.o: libsais.h libsais64.h kommon.h ketopt.h mbpriv.h minibwa.h l2bit.h
+index.o: bwt.h bseq.h
 kalloc.o: kalloc.h
 kommon.o: kommon.h
 ksw2_extd2_sse.o: ksw2.h

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,21 @@ MALLOC_O=	mimalloc.o
 PROG=		minibwa
 LIBS=		-lpthread -lz -lm
 ARCH=		$(shell uname -m)
-omp=		$(shell printf '\043include <omp.h>\nint main(){return 0;}' | $(CC) -x c -fopenmp -o /dev/null - 2>/dev/null && echo "1" || echo "0")
+UNAME_S=	$(shell uname -s)
+
+# OpenMP is on by default. Linux compilers accept -fopenmp directly; macOS Apple
+# Clang needs -Xpreprocessor -fopenmp plus libomp from Homebrew (default prefix
+# /opt/homebrew/opt/libomp on Apple Silicon, /usr/local/opt/libomp on Intel).
+# Override LIBOMP_PREFIX for a non-Homebrew libomp, or pass omp=0 to disable.
+ifeq ($(UNAME_S),Darwin)
+	LIBOMP_PREFIX?=	$(shell test -d /opt/homebrew/opt/libomp && echo /opt/homebrew/opt/libomp || echo /usr/local/opt/libomp)
+	omp_cflags=	-Xpreprocessor -fopenmp -I$(LIBOMP_PREFIX)/include
+	omp_libs=	-L$(LIBOMP_PREFIX)/lib -Wl,-rpath,$(LIBOMP_PREFIX)/lib -lomp
+else
+	omp_cflags=	-fopenmp
+	omp_libs=	-fopenmp
+endif
+omp?=		$(shell printf '\043include <omp.h>\nint main(){return omp_get_max_threads();}' | $(CC) -x c $(omp_cflags) - $(omp_libs) -o /dev/null 2>/dev/null && echo "1" || echo "0")
 
 ifneq ($(asan),)
 	CFLAGS+=-fsanitize=address
@@ -20,8 +34,8 @@ endif
 
 ifeq ($(omp),1)
 	CPPFLAGS+=-DLIBSAIS_OPENMP
-	CFLAGS+=-fopenmp
-	LIBS+=-fopenmp
+	CFLAGS+=$(omp_cflags)
+	LIBS+=$(omp_libs)
 endif
 
 ifneq ($(gpl),0)

--- a/api-test/Makefile
+++ b/api-test/Makefile
@@ -2,6 +2,23 @@ CC=			gcc
 CFLAGS=		-std=gnu99 -Wall -O3
 EXE=		mbmap-one mbmap-batch
 
+# libminibwa.a may contain OpenMP code (parallel BWT construction), so the
+# example programs must link the OpenMP runtime. Mirror the parent Makefile's
+# detection so the setting matches the library that was built.
+UNAME_S=	$(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	LIBOMP_PREFIX?=	$(shell test -d /opt/homebrew/opt/libomp && echo /opt/homebrew/opt/libomp || echo /usr/local/opt/libomp)
+	omp_cflags=	-Xpreprocessor -fopenmp -I$(LIBOMP_PREFIX)/include
+	omp_libs=	-L$(LIBOMP_PREFIX)/lib -Wl,-rpath,$(LIBOMP_PREFIX)/lib -lomp
+else
+	omp_cflags=	-fopenmp
+	omp_libs=	-fopenmp
+endif
+omp?=		$(shell printf '\043include <omp.h>\nint main(){return omp_get_max_threads();}' | $(CC) -x c $(omp_cflags) - $(omp_libs) -o /dev/null 2>/dev/null && echo "1" || echo "0")
+ifeq ($(omp),1)
+	LIBS+=$(omp_libs)
+endif
+
 .PHONY:all clean
 
 all:$(EXE)
@@ -10,10 +27,10 @@ all:$(EXE)
 	(cd ..; make libminibwa.a)
 
 mbmap-one:ex-one.c ../libminibwa.a
-	$(CC) $(CFLAGS) -o $@ -I.. $^ -lz -lm
+	$(CC) $(CFLAGS) -o $@ -I.. $^ -lz -lm $(LIBS)
 
 mbmap-batch:ex-batch.c ../libminibwa.a
-	$(CC) $(CFLAGS) -o $@ -I.. $^ -lz -lm
+	$(CC) $(CFLAGS) -o $@ -I.. $^ -lz -lm $(LIBS)
 
 clean:
 	rm -f $(EXE)

--- a/bwt.c
+++ b/bwt.c
@@ -3,6 +3,9 @@
 #include <string.h>
 #include <assert.h>
 #include <stdint.h>
+#ifdef LIBSAIS_OPENMP
+#include <omp.h>
+#endif
 #include "kommon.h"
 #include "kalloc.h"
 #include "bwt.h"
@@ -102,6 +105,119 @@ mb_bwt_t *mb_bwt_init_from_raw(int is_byte, const void *raw_, uint64_t len, uint
 	for (i = 0, bwt->L2[0] = 0; i < 4; ++i)
 		bwt->L2[i+1] = bwt->L2[i] + c[i];
 	assert(bwt->L2[4] == len);
+	return bwt;
+}
+
+// Build the rank dict from a byte-packed inverted SA (one BWT char per byte,
+// lower 2 bits used). The single k where a[k]==0 is the implicit $
+// ('primary') and is skipped here. Distinct from mb_bwt_init_from_raw above
+// (which packs 4 chars/byte for the GPL bwtgen path) to keep its hot loop
+// branch-free.
+//
+// Parallel via a 3-phase scan: each thread packs its blocks' BWT bits and a
+// local count starting from zero; serial prefix-sum yields per-thread start
+// offsets; each thread then adds its start offset to the lower 56 bits of
+// every block-count word it owns. The byte-64 delta in the upper 8 bits is
+// invariant under that shift, so phase 3 leaves it alone.
+mb_bwt_t *mb_bwt_init_from_inverted_sa(const uint8_t *a, int64_t len, int64_t primary, int n_thread)
+{
+	mb_bwt_t *bwt;
+	int64_t total_blocks = (len + 127) / 128;
+	uint64_t *delta_c, *start_c;
+	int nt, n_used;
+
+	bwt = mb_bwt_init();
+	bwt->primary = primary;
+	bwt->seq_len = len;
+	bwt->data_len = mb_bwt_data_len(len);
+	bwt->data = kom_malloc(uint64_t, bwt->data_len);
+
+#ifdef LIBSAIS_OPENMP
+	nt = n_thread;
+#else
+	nt = 1;
+#endif
+	n_used = nt; // real thread count; corrected to omp_get_num_threads() inside the region
+	delta_c = kom_malloc(uint64_t, (size_t)nt * 4);
+	start_c = kom_calloc(uint64_t, (size_t)(nt + 1) * 4); // start_c[0..3] must be zero for the prefix-scan base
+
+#ifdef LIBSAIS_OPENMP
+	#pragma omp parallel num_threads(nt)
+#endif
+	{
+#ifdef LIBSAIS_OPENMP
+		int tid = omp_get_thread_num();
+		int actual_nt = omp_get_num_threads();
+#else
+		int tid = 0, actual_nt = 1;
+#endif
+		int64_t blocks_per_t = (total_blocks + actual_nt - 1) / actual_nt;
+		int64_t b_first = (int64_t)tid * blocks_per_t;
+		int64_t b_last  = b_first + blocks_per_t;
+		if (b_first > total_blocks) b_first = total_blocks;
+		if (b_last  > total_blocks) b_last  = total_blocks;
+		int64_t out_start = b_first * 128;
+		int64_t out_end   = b_last  * 128;
+		if (out_end > len) out_end = len;
+		uint64_t local_c[4] = {0,0,0,0};
+		uint64_t local_x[4] = {0,0,0,0};
+		uint64_t *block_count_ptr = 0;
+		int64_t k_data = b_first * 8;
+
+		for (int64_t out = out_start; out < out_end; ++out) {
+			int64_t in = out + (out >= primary);
+			uint8_t b = a[in] & 3;
+			int pos = (int)(out & 0x7f);
+			if (pos == 0) {
+				if (out > out_start) memcpy(&bwt->data[k_data], local_x, 32), k_data += 4;
+				block_count_ptr = &bwt->data[k_data];
+				memcpy(&bwt->data[k_data], local_c, 32), k_data += 4;
+				memset(local_x, 0, 32);
+			} else if (pos == 64) {
+				for (int j = 0; j < 4; ++j)
+					block_count_ptr[j] |= (local_c[j] - block_count_ptr[j]) << BWT_CNT_SHIFT;
+			}
+			++local_c[b];
+			local_x[pos >> 5] |= (uint64_t)b << ((pos & 0x1f) << 1);
+		}
+
+		if (b_last > b_first) memcpy(&bwt->data[k_data], local_x, 32), k_data += 4;
+		assert(k_data == b_last * 8);
+		for (int j = 0; j < 4; ++j) delta_c[(size_t)tid * 4 + j] = local_c[j];
+
+#ifdef LIBSAIS_OPENMP
+		#pragma omp barrier
+		#pragma omp single
+#endif
+		{ // OpenMP may give fewer threads than requested; record the real count
+			n_used = actual_nt;
+			for (int t = 0; t < actual_nt; ++t)
+				for (int j = 0; j < 4; ++j)
+					start_c[(size_t)(t+1) * 4 + j] = start_c[(size_t)t * 4 + j] + delta_c[(size_t)t * 4 + j];
+		}
+
+		uint64_t add[4] = {
+			start_c[(size_t)tid * 4 + 0], start_c[(size_t)tid * 4 + 1],
+			start_c[(size_t)tid * 4 + 2], start_c[(size_t)tid * 4 + 3]
+		};
+		for (int64_t b = b_first; b < b_last; ++b) {
+			uint64_t *p = &bwt->data[b * 8];
+			for (int j = 0; j < 4; ++j) {
+				uint64_t low = p[j] & BWT_CNT_MASK, high = p[j] & ~BWT_CNT_MASK;
+				p[j] = ((low + add[j]) & BWT_CNT_MASK) | high;
+			}
+		}
+	}
+
+	memcpy(&bwt->data[total_blocks * 8], &start_c[(size_t)n_used * 4], 32);
+	bwt->L2[0] = 0;
+	for (int j = 0; j < 4; ++j)
+		bwt->L2[j+1] = bwt->L2[j] + start_c[(size_t)n_used * 4 + j];
+	assert(bwt->L2[4] == (uint64_t)len);
+	assert((uint64_t)(total_blocks * 8 + 4) == bwt->data_len);
+
+	free(delta_c);
+	free(start_c);
 	return bwt;
 }
 

--- a/bwt.h
+++ b/bwt.h
@@ -53,6 +53,7 @@ mb_bwt_t *mb_bwt_load_raw(const char *fn); // from raw bwt_gen.c output
 int mb_bwt_save(const char *fn, const mb_bwt_t *bwt);
 mb_bwt_t *mb_bwt_load(const char *fn);
 mb_bwt_t *mb_bwt_init_from_raw(int is_byte, const void *raw_, uint64_t len, uint64_t primary);
+mb_bwt_t *mb_bwt_init_from_inverted_sa(const uint8_t *a, int64_t len, int64_t primary, int n_thread);
 
 void mb_bwt_cache(mb_bwt_t *bwt, int32_t len);
 uint64_t mb_bwt_rank11(const mb_bwt_t *bwt, uint64_t k, uint8_t c);

--- a/index.c
+++ b/index.c
@@ -1,6 +1,8 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <stdint.h>
+#include "libsais.h"
 #include "libsais64.h"
 #include "kommon.h"
 #include "ketopt.h"
@@ -17,7 +19,27 @@ static ko_longopt_t long_opts[] = { // common long options shared across all ind
 static inline uint8_t l2b_c2t(uint8_t b) { return b == 1? 3 : b; } // C(1) -> T(3)
 static inline uint8_t l2b_g2a(uint8_t b) { return b == 2? 0 : b; } // G(2) -> A(0)
 
-static mb_bwt_t *mb_bwt_libsais(const l2b_t *l2b, int sa_bit, int both_strand, int is_meth, int n_thread)
+// Base at position `in` of the (possibly meth-converted) concatenated reference.
+// Non-meth: forward copy then its reverse complement. Meth: c2t_f, g2a_f, g2a_r,
+// c2t_r. Must match the serial fill in mb_bwt_libsais_serial exactly; shared by
+// the parallel fill and the parallel BWT inversion so the two stay consistent.
+static inline uint8_t l2b_seqbase(const l2b_t *l2b, int is_meth, int both_strand, int64_t n_fwd, int64_t in)
+{
+	if (!is_meth)
+		return (both_strand && in >= n_fwd)? 3 - l2b_get0(l2b, 2*n_fwd - 1 - in) : l2b_get0(l2b, in);
+	if (in < n_fwd)        return l2b_c2t(l2b_get0(l2b, in));               // c2t forward
+	else if (in < 2*n_fwd) return l2b_g2a(l2b_get0(l2b, in - n_fwd));       // g2a forward
+	else if (in < 3*n_fwd) return 3 - l2b_g2a(l2b_get0(l2b, 3*n_fwd - 1 - in)); // g2a reverse
+	else                   return 3 - l2b_c2t(l2b_get0(l2b, 4*n_fwd - 1 - in)); // c2t reverse
+}
+
+// Serial pipeline used when n_thread <= 1. Mirrors the original (pre-parallel)
+// minibwa path: serial seq fill, libsais64, serial SSA + BWT inversion via
+// seq[v-1], serial copy-shift back into seq[], and mb_bwt_init_from_raw on the
+// byte-packed BWT. Avoids OpenMP outlining overhead (no parallelism to win
+// back) and the post-libsais compaction pass (no late-stage memory pressure
+// matters when the user explicitly asked for one core).
+static mb_bwt_t *mb_bwt_libsais_serial(const l2b_t *l2b, int sa_bit, int both_strand, int is_meth)
 {
 	const int fs = 10000;
 	uint8_t *seq;
@@ -51,31 +73,158 @@ static mb_bwt_t *mb_bwt_libsais(const l2b_t *l2b, int sa_bit, int both_strand, i
 				seq[j] = 3 - l2b_get0(l2b, i);
 	}
 #ifdef LIBSAIS_OPENMP
-    libsais64_omp(seq, a + 1, len, fs, 0, n_thread);
+	libsais64_omp(seq, a + 1, len, fs, 0, 1);
 #else
-    libsais64(seq, a + 1, len, fs, 0);
+	libsais64(seq, a + 1, len, fs, 0);
 #endif
-	a[0] = len; // libsais doesn't write a[0], which always equals to len
+	a[0] = len;
 
-	n_ssa = (len + (1<<sa_bit)) >> sa_bit;
-	ssa = kom_calloc(uint64_t, n_ssa);
-	mask = (1<<sa_bit) - 1;
+	n_ssa = (len + (1ULL<<sa_bit)) >> sa_bit;
+	ssa = kom_malloc(uint64_t, n_ssa);
+	mask = (1ULL << sa_bit) - 1;
 	for (i = 0; i <= len; ++i)
 		if ((i & mask) == 0)
 			ssa[i >> sa_bit] = a[i];
 	ssa[0] = (uint64_t)-1;
-	primary = (uint64_t)-1;
+
+	primary = -1;
 	for (i = 0; i <= len; ++i) {
 		if (a[i] == 0) primary = i;
 		else a[i] = seq[a[i] - 1];
 	}
-	assert(primary != (uint64_t)-1);
+	assert(primary != -1);
+
 	for (i = 0; i < primary; ++i) seq[i] = a[i];
-	for (; i < len; ++i) seq[i] = a[i + 1];
+	for (i = primary; i < len; ++i) seq[i] = a[i + 1];
 	free(a);
+
 	bwt = mb_bwt_init_from_raw(1, seq, len, primary);
 	bwt->sa_bit = sa_bit, bwt->n_sa = n_ssa, bwt->sa = ssa;
 	free(seq);
+	return bwt;
+}
+
+static mb_bwt_t *mb_bwt_libsais(const l2b_t *l2b, int sa_bit, int both_strand, int is_meth, int n_thread)
+{
+	const int fs = 10000;
+	uint8_t *seq, *bwt_byte;
+	int64_t primary, len, n_fwd;
+	mb_bwt_t *bwt;
+	uint64_t *ssa, n_ssa, mask;
+	void *a;
+	int use_int32;
+
+	if (n_thread <= 1) return mb_bwt_libsais_serial(l2b, sa_bit, both_strand, is_meth);
+
+	n_fwd = l2b->tot_len;
+	len = n_fwd * (is_meth? 2 : 1) * (both_strand? 2 : 1);
+	// 32-bit SA cuts allocation and read bandwidth in half on inputs below ~2 Gbp,
+	// which covers single human chromosomes and most non-mammalian genomes.
+	use_int32 = len + fs + 1 <= INT32_MAX;
+
+	seq = kom_malloc(uint8_t, len);
+	a = use_int32? (void*)kom_malloc(int32_t, len + fs + 1)
+	             : (void*)kom_malloc(int64_t, len + fs + 1);
+
+#ifdef LIBSAIS_OPENMP
+	#pragma omp parallel for num_threads(n_thread) schedule(static)
+#endif
+	for (int64_t k = 0; k < len; ++k)
+		seq[k] = l2b_seqbase(l2b, is_meth, both_strand, n_fwd, k);
+
+	if (use_int32) {
+		int32_t *a32 = a;
+#ifdef LIBSAIS_OPENMP
+		libsais_omp(seq, a32 + 1, (int32_t)len, fs, 0, n_thread);
+#else
+		libsais(seq, a32 + 1, (int32_t)len, fs, 0);
+#endif
+		a32[0] = (int32_t)len;
+	} else {
+		int64_t *a64 = a;
+#ifdef LIBSAIS_OPENMP
+		libsais64_omp(seq, a64 + 1, len, fs, 0, n_thread);
+#else
+		libsais64(seq, a64 + 1, len, fs, 0);
+#endif
+		a64[0] = len;
+	}
+	free(seq);  // freed early; the fused inversion below reads l2b directly (4x denser)
+
+	n_ssa = (len + (1ULL<<sa_bit)) >> sa_bit;
+	ssa = kom_malloc(uint64_t, n_ssa);
+	mask = (1ULL << sa_bit) - 1;
+	primary = -1;
+
+	// Fused SSA sampling + BWT inversion. Reads the BWT character via l2b
+	// instead of via seq[] so we can free seq[] before this loop. Exactly one
+	// iteration sees a[k]==0 (libsais's $-marker); the atomic makes that
+	// single store well-defined under the OpenMP memory model.
+	if (use_int32) {
+		int32_t *a32 = a;
+#ifdef LIBSAIS_OPENMP
+		#pragma omp parallel for num_threads(n_thread) schedule(static)
+#endif
+		for (int64_t k = 0; k <= len; ++k) {
+			int32_t v = a32[k];
+			if (((uint64_t)k & mask) == 0) ssa[(uint64_t)k >> sa_bit] = (uint64_t)(uint32_t)v;
+			if (v == 0) {
+#ifdef LIBSAIS_OPENMP
+				#pragma omp atomic write
+#endif
+				primary = k;
+			} else {
+				int64_t in = v - 1;
+				a32[k] = l2b_seqbase(l2b, is_meth, both_strand, n_fwd, in);
+			}
+		}
+	} else {
+		int64_t *a64 = a;
+#ifdef LIBSAIS_OPENMP
+		#pragma omp parallel for num_threads(n_thread) schedule(static)
+#endif
+		for (int64_t k = 0; k <= len; ++k) {
+			int64_t v = a64[k];
+			if (((uint64_t)k & mask) == 0) ssa[(uint64_t)k >> sa_bit] = (uint64_t)v;
+			if (v == 0) {
+#ifdef LIBSAIS_OPENMP
+				#pragma omp atomic write
+#endif
+				primary = k;
+			} else {
+				int64_t in = v - 1;
+				a64[k] = l2b_seqbase(l2b, is_meth, both_strand, n_fwd, in);
+			}
+		}
+	}
+	ssa[0] = (uint64_t)-1;
+	assert(primary != -1);
+
+	// Compact a[] (int32 or int64 with BWT chars in lower 2 bits) into a
+	// byte-packed buffer, then free the wide a[]. This drops late-stage memory
+	// from 4n or 8n to n bytes (e.g. ~45 GB on hg38), letting init_from_inverted_sa
+	// run with much more headroom. Peak is unchanged: the wide a[] is freed
+	// only after the byte buffer is full, and the byte buffer reuses the
+	// allocator slot left by the freed seq[].
+	bwt_byte = kom_malloc(uint8_t, len + 1);
+	if (use_int32) {
+		int32_t *a32 = a;
+#ifdef LIBSAIS_OPENMP
+		#pragma omp parallel for num_threads(n_thread) schedule(static)
+#endif
+		for (int64_t k = 0; k <= len; ++k) bwt_byte[k] = (uint8_t)(a32[k] & 3);
+	} else {
+		int64_t *a64 = a;
+#ifdef LIBSAIS_OPENMP
+		#pragma omp parallel for num_threads(n_thread) schedule(static)
+#endif
+		for (int64_t k = 0; k <= len; ++k) bwt_byte[k] = (uint8_t)(a64[k] & 3);
+	}
+	free(a);
+
+	bwt = mb_bwt_init_from_inverted_sa(bwt_byte, len, primary, n_thread);
+	bwt->sa_bit = sa_bit, bwt->n_sa = n_ssa, bwt->sa = ssa;
+	free(bwt_byte);
 	return bwt;
 }
 
@@ -265,6 +414,8 @@ int main_index(int argc, char *argv[])
 		else if (c == 902) is_meth = 1;
 	}
 	if (argc - o.ind == 0) return usage_index(stderr, seed, sa_bit, n_thread);
+	if (n_thread < 1) n_thread = 1;
+	kom_assert(sa_bit >= 0 && sa_bit < 32, "-u must be in [0, 31]");
 
 	prefix = o.ind + 1 < argc? argv[o.ind+1] : argv[o.ind];
 	fn_l2b = kom_calloc(char, strlen(prefix) + 10);


### PR DESCRIPTION
hg38 (3.2 Gbp single-strand, m7a.4xlarge / AMD Zen 4 / 64 GiB, median of 2):

| -t |  master | this PR | speedup |
|---:|--------:|--------:|--------:|
|  1 |   365.3 |   366.5 |   1.00× |
|  2 |   333.9 |   316.5 |   1.06× |
|  4 |   241.6 |   201.2 |   1.20× |
|  8 |   198.3 |   143.6 |   1.38× |
| 16 |   179.6 |   120.7 |   1.49× |

1→16: this PR 3.04×, master 2.03×.

`mb_bwt_libsais` restructured. SSA sampling, BWT inversion, and rank-dict are fused into one parallel pipeline; new `mb_bwt_init_from_inverted_sa` does the rank-dict via a 3-phase scan (kept separate from `mb_bwt_init_from_raw`, which still serves the GPL `bwtgen` path). Reads `l2b` directly during inversion so `seq[]` is freed right after libsais; then compacts the int32/int64 SA buffer to byte-packed BWT, dropping ~45 GB of post-libsais working set on hg38. 32-bit SA when `len + fs + 1 ≤ INT32_MAX`. Serial fallback for `n_thread ≤ 1` mirrors the previous pipeline (no OMP outlining, no compaction pass). CLI validates `-t` and `-u` at the boundary.

Makefile: macOS auto-detects Homebrew libomp (`-Xpreprocessor -fopenmp` + `LIBOMP_PREFIX` autodetect + `-Wl,-rpath`). Linux unchanged. OpenMP is on by default; `make omp=0` opts out.

libsais's three induced-sort phases account for 88% of its wall at -t 8 and each scale 1.5-1.7× — the SA-IS algorithmic ceiling, matching libsais's own published numbers. Speedup gains here come from the surrounding 4-7×-scaling work.

## Rebased onto the 4-base meth master

master gained the 4-base bisulfite index (4 converted copies per contig) after this PR was written; the parallel path now handles it. A shared `l2b_seqbase(in)` helper returns the (possibly c2t/g2a-converted) reference base at concatenated position `in`, used by both the parallel fill and the parallel inversion so they stay consistent. Non-meth output is unchanged.

`api-test/Makefile` also needed the OpenMP runtime (`libminibwa.a` now carries GOMP symbols → `undefined reference to GOMP_parallel`); fixed by linking `$(omp_libs)`. Added a `macos-latest` CI job exercising the libomp build path (previously untested). Both CI jobs green.

Speedup corroborated on m7a.8xlarge (32 vCPU): 1.34× at `-t 8`, 1.56× at `-t 32`, scaling 3.33× — consistent with the m7a.4xlarge table above.

## Test plan

- [x] bit-identical to master on chr22 and chr1+chr2 at `-t 1, 2, 4, 8`
- [x] hg38 builds at `-t 1, 2, 4, 8, 16` on a 64 GiB instance
- [x] `omp=0` produces a working binary
- [x] bit-identical to master for the `--meth` index too (chrM `-t 1,2,4,8`; chr17 `-t 8`)
- [x] `api-test` builds + `macos-latest` CI job green
