### PR TITLE
feat: --meth bisulfite alignment + cross-contig PE pairing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS=		-std=c99 -g -Wall -O3
 CPPFLAGS=
 LDFLAGS=
 INCLUDES=
-LOBJS=		kommon.o kalloc.o bwt.o l2bit.o options.o seed.o map-algo.o lchain.o align.o pe.o cs.o format.o \
+LOBJS=		kommon.o kalloc.o bwt.o l2bit.o options.o seed.o map-algo.o lchain.o align.o pe.o cs.o format.o meth.o \
 			ksw2_extz2_sse.o ksw2_extd2_sse.o ksw2_ll_sse.o
 AOBJS=		kthread.o libsais.o libsais64.o index.o bseq.o map-main.o fastmap.o
 MALLOC_O=	mimalloc.o
@@ -71,9 +71,10 @@ bwtgen.o: QSufSort.h
 cs.o: mbpriv.h minibwa.h l2bit.h bwt.h kommon.h bseq.h kalloc.h
 fastmap.o: mbpriv.h minibwa.h l2bit.h bwt.h kommon.h bseq.h ketopt.h kseq.h
 fastmap.o: kalloc.h
-format.o: mbpriv.h minibwa.h l2bit.h bwt.h kommon.h bseq.h
+format.o: mbpriv.h minibwa.h l2bit.h bwt.h kommon.h bseq.h meth.h
 index.o: libsais64.h kommon.h ketopt.h mbpriv.h minibwa.h l2bit.h bwt.h
-index.o: bseq.h
+index.o: bseq.h kseq.h
+meth.o: meth.h l2bit.h
 kalloc.o: kalloc.h
 kommon.o: kommon.h
 ksw2_extd2_sse.o: ksw2.h

--- a/align.c
+++ b/align.c
@@ -326,10 +326,11 @@ static inline int32_t max_bw_from_mm(const mb_opt_t *opt, int32_t mm)
 }
 
 static void mb_align_pair(void *km, const mb_opt_t *opt, int qlen, const uint8_t *qseq, int tlen, const uint8_t *tseq,
-						  const int8_t *mat, int w, int end_bonus, int zdrop, int ksw_flag, ksw_extz_t *ez)
+						  const int8_t *mat, int w, int end_bonus, int pen_clip, int zdrop, int ksw_flag, ksw_extz_t *ez)
 {
 	const int max_bw_adj_len = 100; // don't adjust bandwidth if sequences are too long
 	int32_t j, n_mm = -1;
+	int eff_end_bonus = end_bonus >= 0? end_bonus + pen_clip : end_bonus; // -1 sentinel = no bonus
 	if (opt->b_ts != 0 && opt->b != opt->b_ts) { // distinguish ts vs tv
 		ksw_flag |= KSW_EZ_GENERIC_SC;
 	} else if ((ksw_flag & KSW_EZ_EXTZ_ONLY) && tlen >= qlen) { // ungapped extension
@@ -341,7 +342,7 @@ static void mb_align_pair(void *km, const mb_opt_t *opt, int qlen, const uint8_t
 		}
 		if (n_mm <= 2) {
 			ez->mqe = ez->score, ez->mqe_t = qlen - 1;
-			if (ez->mqe + end_bonus >= ez->max) {
+			if (ez->mqe + eff_end_bonus >= ez->max) {
 				ez->reach_end = 1;
 				ez->cigar = ksw_push_cigar(km, &ez->n_cigar, &ez->m_cigar, ez->cigar, MB_CIGAR_MATCH, qlen);
 				return;
@@ -370,9 +371,9 @@ static void mb_align_pair(void *km, const mb_opt_t *opt, int qlen, const uint8_t
 		ksw_reset_extz(ez);
 		ez->zdropped = 1;
 	} else if (opt->q == opt->q2 && opt->e == opt->e2) { // affine gap
-		ksw_extz2_sse(km, qlen, qseq, tlen, tseq, 5, mat, opt->q, opt->e, w, zdrop * opt->a, end_bonus, ksw_flag, ez);
+		ksw_extz2_sse(km, qlen, qseq, tlen, tseq, 5, mat, opt->q, opt->e, w, zdrop * opt->a, eff_end_bonus, ksw_flag, ez);
 	} else { // dual affine gap
-		ksw_extd2_sse(km, qlen, qseq, tlen, tseq, 5, mat, opt->q, opt->e, opt->q2, opt->e2, w, zdrop * opt->a, end_bonus, ksw_flag, ez);
+		ksw_extd2_sse(km, qlen, qseq, tlen, tseq, 5, mat, opt->q, opt->e, opt->q2, opt->e2, w, zdrop * opt->a, eff_end_bonus, ksw_flag, ez);
 	}
 	if (kom_dbg_flag & MB_DBG_ALN_SEQ) {
 		int i;
@@ -639,7 +640,7 @@ static void mb_align1(void *km, const mb_opt_t *opt, const mb_idx_t *mi, int qle
 		l2b_getseq(mi->l2b, tid, ts0, ts, tseq);
 		mb_seq_rev(qs - qs0, qseq);
 		mb_seq_rev(ts - ts0, tseq);
-		mb_align_pair(km, opt, qs - qs0, qseq, ts - ts0, tseq, mat, bw, opt->end_bonus, r->split_inv? opt->zdrop_inv : opt->zdrop, ksw_flag|KSW_EZ_EXTZ_ONLY|KSW_EZ_RIGHT|KSW_EZ_REV_CIGAR, ez);
+		mb_align_pair(km, opt, qs - qs0, qseq, ts - ts0, tseq, mat, bw, opt->end_bonus, opt->pen_clip5, r->split_inv? opt->zdrop_inv : opt->zdrop, ksw_flag|KSW_EZ_EXTZ_ONLY|KSW_EZ_RIGHT|KSW_EZ_REV_CIGAR, ez);
 		if (ez->n_cigar > 0) {
 			mb_append_cigar(r, ez->n_cigar, ez->cigar);
 			r->p->dp_score += ez->reach_end? ez->mqe : ez->max;
@@ -684,10 +685,10 @@ static void mb_align1(void *km, const mb_opt_t *opt, const mb_idx_t *mi, int qle
 			// perform alignment
 			qseq = &qseq0[rev][qs];
 			l2b_getseq(mi->l2b, tid, ts, te, tseq);
-			mb_align_pair(km, opt, qe - qs, qseq, te - ts, tseq, mat, bw1, -1, opt->zdrop, ksw_flag|KSW_EZ_APPROX_MAX, ez); // first pass: with approximate Z-drop
+			mb_align_pair(km, opt, qe - qs, qseq, te - ts, tseq, mat, bw1, -1, 0, opt->zdrop, ksw_flag|KSW_EZ_APPROX_MAX, ez); // first pass: with approximate Z-drop
 			// test Z-drop and inversion Z-drop
 			if ((zdrop_code = mm_test_zdrop(km, opt, qseq, tseq, ez->n_cigar, ez->cigar, mat, is_sr)) != 0)
-				mb_align_pair(km, opt, qe - qs, qseq, te - ts, tseq, mat, bw1, -1, zdrop_code == 2? opt->zdrop_inv : opt->zdrop, ksw_flag, ez); // second pass: lift approximate
+				mb_align_pair(km, opt, qe - qs, qseq, te - ts, tseq, mat, bw1, -1, 0, zdrop_code == 2? opt->zdrop_inv : opt->zdrop, ksw_flag, ez); // second pass: lift approximate
 			if (kom_dbg_flag & MB_DBG_AN_POS) fprintf(stderr, "AD\t%d\t%ld\t%ld\t%d\t%d\t%d\t%d\n", r->as, (long)ts, (long)te, qs, qe, zdrop_code, ez->zdropped);
 			// update CIGAR
 			if (ez->n_cigar > 0)
@@ -729,7 +730,7 @@ static void mb_align1(void *km, const mb_opt_t *opt, const mb_idx_t *mi, int qle
 	if (!dropped && qe < qe0 && te < te0) { // right extension
 		qseq = &qseq0[rev][qe];
 		l2b_getseq(mi->l2b, tid, te, te0, tseq);
-		mb_align_pair(km, opt, qe0 - qe, qseq, te0 - te, tseq, mat, bw, opt->end_bonus, opt->zdrop, ksw_flag|KSW_EZ_EXTZ_ONLY, ez);
+		mb_align_pair(km, opt, qe0 - qe, qseq, te0 - te, tseq, mat, bw, opt->end_bonus, opt->pen_clip3, opt->zdrop, ksw_flag|KSW_EZ_EXTZ_ONLY, ez);
 		if (ez->n_cigar > 0) {
 			mb_append_cigar(r, ez->n_cigar, ez->cigar);
 			r->p->dp_score += ez->reach_end? ez->mqe : ez->max;
@@ -784,7 +785,7 @@ static int mb_align1_inv(void *km, const mb_opt_t *opt, const mb_idx_t *mi, int 
 	mb_seq_rev(tl, tseq);
 	if (score < opt->min_dp_max * opt->a) goto end_align1_inv;
 	q_off = ql - (q_off + 1), t_off = tl - (t_off + 1);
-	mb_align_pair(km, opt, ql - q_off, qseq + q_off, tl - t_off, tseq + t_off, mat, (int)(opt->bw * 1.5), -1, opt->zdrop, KSW_EZ_EXTZ_ONLY, ez);
+	mb_align_pair(km, opt, ql - q_off, qseq + q_off, tl - t_off, tseq + t_off, mat, (int)(opt->bw * 1.5), -1, 0, opt->zdrop, KSW_EZ_EXTZ_ONLY, ez);
 	if (ez->n_cigar == 0) goto end_align1_inv; // should never be here
 	mb_append_cigar(r_inv, ez->n_cigar, ez->cigar);
 	r_inv->p->dp_score = ez->max;

--- a/api-test/Makefile
+++ b/api-test/Makefile
@@ -1,10 +1,13 @@
 CC=			gcc
 CFLAGS=		-std=gnu99 -Wall -O3
-EXE=		mbmap-sgl mbmap-batch
+EXE=		mbmap-sgl mbmap-batch test-meth-cmap
 
-.PHONY:all clean
+.PHONY:all clean test
 
 all:$(EXE)
+
+test:test-meth-cmap
+	./test-meth-cmap
 
 ../libminibwa.a:
 	(cd ..; make libminibwa.a)
@@ -14,6 +17,9 @@ mbmap-sgl:ex-sgl.c ../libminibwa.a
 
 mbmap-batch:ex-batch.c ../libminibwa.a
 	$(CC) $(CFLAGS) -o $@ -I.. $^ -lz -lm
+
+test-meth-cmap:ex-meth-cmap.c ../libminibwa.a
+	$(CC) $(CFLAGS) -o $@ -I.. $^ -lz -lm -lpthread
 
 clean:
 	rm -f $(EXE)

--- a/api-test/ex-meth-cmap.c
+++ b/api-test/ex-meth-cmap.c
@@ -1,0 +1,142 @@
+/* Smoke tests for mb_meth_cmap_build: f<X>/r<X> partner detection,
+ * 3+-collision poisoning, length-mismatch fallback. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "l2bit.h"
+#include "meth.h"
+
+static l2b_t make_l2b(int n, const char **names, const uint64_t *lens)
+{
+	l2b_t l = {0};
+	int i;
+	l.n_ctg = n;
+	l.ctg = calloc(n, sizeof(l2b_ctg_t));
+	for (i = 0; i < n; ++i) {
+		l.ctg[i].name = strdup(names[i]);
+		l.ctg[i].len  = lens[i];
+		l.ctg[i].off  = (uint64_t)i * 1000;
+	}
+	return l;
+}
+
+static void free_l2b(l2b_t *l)
+{
+	uint64_t i;
+	for (i = 0; i < l->n_ctg; ++i) free(l->ctg[i].name);
+	free(l->ctg);
+}
+
+static int n_pass, n_fail;
+#define CHECK(cond, msg) do { \
+	if (cond) { ++n_pass; } \
+	else { ++n_fail; fprintf(stderr, "  FAIL: %s (line %d)\n", msg, __LINE__); } \
+} while (0)
+
+static void test_no_doubled(void)
+{
+	const char *names[] = {"chr1", "chr2"};
+	const uint64_t lens[] = {1000, 2000};
+	l2b_t l = make_l2b(2, names, lens);
+	mb_meth_cmap_t *m = mb_meth_cmap_build(&l);
+	fprintf(stderr, "test_no_doubled:\n");
+	CHECK(m->n_internal == 2, "n_internal");
+	CHECK(m->n_output == 2, "n_output");
+	CHECK(m->canon_tid[0] == 0 && m->canon_tid[1] == 1, "canon_tid identity");
+	CHECK(m->paired_tid[0] == -1 && m->paired_tid[1] == -1, "no partners");
+	CHECK(m->direction[0] == 0 && m->direction[1] == 0, "no direction");
+	mb_meth_cmap_free(m);
+	free_l2b(&l);
+}
+
+static void test_paired_fr(void)
+{
+	const char *names[] = {"fchr1", "rchr1"};
+	const uint64_t lens[] = {1000, 1000};
+	l2b_t l = make_l2b(2, names, lens);
+	mb_meth_cmap_t *m = mb_meth_cmap_build(&l);
+	fprintf(stderr, "test_paired_fr:\n");
+	CHECK(m->n_internal == 2 && m->n_output == 1, "collapse");
+	CHECK(m->canon_tid[0] == 0 && m->canon_tid[1] == 0, "canon=0 for both");
+	CHECK(m->paired_tid[0] == 1 && m->paired_tid[1] == 0, "partners cross-link");
+	CHECK(m->direction[0] == 'f' && m->direction[1] == 'r', "direction");
+	CHECK(m->out_tid[0] == 0 && m->out_tid[1] == 0, "shared out_tid");
+	CHECK(strcmp(m->output_names[0], "chr1") == 0, "stripped name");
+	mb_meth_cmap_free(m);
+	free_l2b(&l);
+}
+
+static void test_three_collision(void)
+{
+	/* All three names must strip to the same string ("chr1") to share an out_tid;
+	 * use two f-prefixed and one r-prefixed dupes. */
+	const char *names[] = {"fchr1", "rchr1", "fchr1"};
+	const uint64_t lens[] = {1000, 1000, 1000};
+	l2b_t l = make_l2b(3, names, lens);
+	mb_meth_cmap_t *m = mb_meth_cmap_build(&l);
+	fprintf(stderr, "test_three_collision:\n");
+	CHECK(m->n_output == 1, "single out_tid");
+	CHECK(m->paired_tid[0] == -1 && m->paired_tid[1] == -1 && m->paired_tid[2] == -1,
+	      "all partners -1 after 3+ collision");
+	mb_meth_cmap_free(m);
+	free_l2b(&l);
+}
+
+static void test_four_collision(void)
+{
+	const char *names[] = {"fchr1", "rchr1", "fchr1", "rchr1"};
+	const uint64_t lens[] = {1000, 1000, 1000, 1000};
+	l2b_t l = make_l2b(4, names, lens);
+	mb_meth_cmap_t *m = mb_meth_cmap_build(&l);
+	fprintf(stderr, "test_four_collision:\n");
+	CHECK(m->n_output == 1, "single out_tid");
+	/* All four must have paired_tid == -1: regression for the toggling-after-poison bug */
+	CHECK(m->paired_tid[0] == -1, "partner[0] -1 after 4-collision");
+	CHECK(m->paired_tid[1] == -1, "partner[1] -1 after 4-collision");
+	CHECK(m->paired_tid[2] == -1, "partner[2] -1 after 4-collision");
+	CHECK(m->paired_tid[3] == -1, "partner[3] -1 after 4-collision");
+	mb_meth_cmap_free(m);
+	free_l2b(&l);
+}
+
+static void test_length_mismatch(void)
+{
+	const char *names[] = {"fchr1", "rchr1"};
+	const uint64_t lens[] = {1000, 1001}; /* mismatched */
+	l2b_t l = make_l2b(2, names, lens);
+	fprintf(stderr, "test_length_mismatch:\n");
+	mb_meth_cmap_t *m = mb_meth_cmap_build(&l);
+	CHECK(m != NULL, "build does not abort on mismatch");
+	CHECK(m->paired_tid[0] == -1 && m->paired_tid[1] == -1, "mismatch -> no partner");
+	mb_meth_cmap_free(m);
+	free_l2b(&l);
+}
+
+static void test_mixed_doubled_and_plain(void)
+{
+	const char *names[] = {"fchr1", "rchr1", "chrM", "fchr2", "rchr2"};
+	const uint64_t lens[] = {1000, 1000, 16569, 2000, 2000};
+	l2b_t l = make_l2b(5, names, lens);
+	mb_meth_cmap_t *m = mb_meth_cmap_build(&l);
+	fprintf(stderr, "test_mixed_doubled_and_plain:\n");
+	CHECK(m->n_output == 3, "chr1, chrM, chr2");
+	CHECK(m->paired_tid[0] == 1 && m->paired_tid[1] == 0, "chr1 partners");
+	CHECK(m->paired_tid[2] == -1, "chrM no partner");
+	CHECK(m->paired_tid[3] == 4 && m->paired_tid[4] == 3, "chr2 partners");
+	CHECK(m->direction[2] == 0, "chrM direction 0");
+	mb_meth_cmap_free(m);
+	free_l2b(&l);
+}
+
+int main(void)
+{
+	test_no_doubled();
+	test_paired_fr();
+	test_three_collision();
+	test_four_collision();
+	test_length_mismatch();
+	test_mixed_doubled_and_plain();
+	fprintf(stderr, "\n%d passed, %d failed\n", n_pass, n_fail);
+	return n_fail == 0? 0 : 1;
+}

--- a/format.c
+++ b/format.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <assert.h>
 #include "mbpriv.h"
 #include "kommon.h"
@@ -101,14 +102,19 @@ err_set_rg:
 	return -1;
 }
 
-int mb_fmt_sam_hdr(kstring_t *str, const l2b_t *idx, const char *rg, const char *ver, int argc, char *argv[])
+int mb_fmt_sam_hdr(kstring_t *str, const l2b_t *idx, const mb_meth_cmap_t *cmap, const char *rg, const char *ver, int argc, char *argv[])
 {
 	int i, ret = 0;
 	str->l = 0;
 	kom_sprintf_lite(str, "@HD\tVN:1.6\tSO:unsorted\tGO:query\n");
-	if (idx)
+	if (cmap) { // --meth: one @SQ per consolidated contig
+		for (i = 0; i < cmap->n_output; ++i)
+			kom_sprintf_lite(str, "@SQ\tSN:%s\tLN:%ld\n",
+				cmap->output_names[i], (long)cmap->output_lens[i]);
+	} else if (idx) {
 		for (i = 0; i < idx->n_ctg; ++i)
 			kom_sprintf_lite(str, "@SQ\tSN:%s\tLN:%ld\n", idx->ctg[i].name, idx->ctg[i].len);
+	}
 	if (rg) ret = sam_write_rg_line(str, rg);
 	kom_sprintf_lite(str, "@PG\tID:minibwa\tPN:minibwa");
 	if (ver) kom_sprintf_lite(str, "\tVN:%s", ver);
@@ -141,6 +147,35 @@ static inline void str_copy(kstring_t *s, const char *st, const char *en)
 	s->l += en - st;
 }
 
+// Append `comment` to `s` (preceded by '\t'). If `filter`, drop segments that don't conform to
+// SAM aux-tag shape `XX:T:...` (T one of A/i/f/Z/H/B). --meth uses filter=1 because YS:Z/YC:Z
+// are stuffed alongside the user's FASTQ comment; non-meth -y is verbatim.
+static void sam_write_comment(kstring_t *s, const char *comment, int filter)
+{
+	const char *p = comment, *seg_start;
+	if (!filter) { kom_sprintf_lite(s, "\t%s", comment); return; }
+	while (*p) {
+		int n, ok;
+		seg_start = p;
+		while (*p && *p != '\t') ++p;
+		n = (int)(p - seg_start);
+		ok = n >= 5
+			&& ((seg_start[0] >= 'A' && seg_start[0] <= 'Z') || (seg_start[0] >= 'a' && seg_start[0] <= 'z'))
+			&& ((seg_start[1] >= 'A' && seg_start[1] <= 'Z') || (seg_start[1] >= 'a' && seg_start[1] <= 'z') || (seg_start[1] >= '0' && seg_start[1] <= '9'))
+			&& seg_start[2] == ':'
+			&& (seg_start[3] == 'A' || seg_start[3] == 'i' || seg_start[3] == 'f' || seg_start[3] == 'Z' || seg_start[3] == 'H' || seg_start[3] == 'B')
+			&& seg_start[4] == ':';
+		if (ok) {
+			str_enlarge(s, n + 1);
+			s->s[s->l++] = '\t';
+			memcpy(&s->s[s->l], seg_start, n);
+			s->l += n;
+			s->s[s->l] = 0;
+		}
+		if (*p == '\t') ++p;
+	}
+}
+
 static void sam_write_sq(kstring_t *s, char *seq, int l, int rev, int comp)
 {
 	if (rev) {
@@ -152,6 +187,28 @@ static void sam_write_sq(kstring_t *s, char *seq, int l, int rev, int comp)
 		}
 		s->l += l;
 	} else str_copy(s, seq, seq + l);
+}
+
+// like sam_write_sq, but uppercases ACGT* (consumers expect uppercase under --meth)
+static void sam_write_sq_upper(kstring_t *s, char *seq, int l, int rev, int comp)
+{
+	int i;
+	str_enlarge(s, l);
+	if (rev) {
+		for (i = 0; i < l; ++i) {
+			int c = (unsigned char)seq[l - 1 - i];
+			char out = (c < 128 && comp) ? (char)kom_comp_table[c] : (char)c;
+			if (out >= 'a' && out <= 'z') out = (char)(out - 32);
+			s->s[s->l + i] = out;
+		}
+	} else {
+		for (i = 0; i < l; ++i) {
+			char out = seq[i];
+			if (out >= 'a' && out <= 'z') out = (char)(out - 32);
+			s->s[s->l + i] = out;
+		}
+	}
+	s->l += l;
 }
 
 static inline const mb_hit_t *get_sam_pri(int n_hit, const mb_hit_t *hit)
@@ -192,7 +249,34 @@ static void write_sam_cigar(kstring_t *s, int sam_flag, int in_tag, int qlen, co
 	}
 }
 
-void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx, int32_t mate_qlen)
+// Pre-c2t bases stashed as YS:Z prefix of t->comment by mb_meth_ingest. NULL on missing/malformed.
+static inline const char *meth_orig_seq(const mb_bseq1_t *t)
+{
+	if (t == 0 || t->comment == 0 || t->l_seq <= 0) return 0;
+	if (memcmp(t->comment, MB_METH_YS_PREFIX, 5) != 0) return 0;
+	if (strlen(t->comment) < (size_t)5 + (size_t)t->l_seq) return 0;
+	return t->comment + 5;
+}
+
+static inline const char *sam_ctg_name(const l2b_t *l2b, const mb_meth_cmap_t *cmap, int64_t tid)
+{
+	if (cmap && tid >= 0 && tid < cmap->n_internal) {
+		int out = cmap->out_tid[tid];
+		if (out >= 0 && out < cmap->n_output) return cmap->output_names[out];
+	}
+	return l2b->ctg[tid].name;
+}
+
+// True if internal tids a, b collapse to the same output contig.
+static inline int sam_same_output_tid(const mb_meth_cmap_t *cmap, int64_t a, int64_t b)
+{
+	if (a == b) return 1;
+	if (cmap && a >= 0 && b >= 0 && a < cmap->n_internal && b < cmap->n_internal)
+		return cmap->out_tid[a] == cmap->out_tid[b];
+	return 0;
+}
+
+void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_meth_cmap_t *cmap, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx, int32_t mate_qlen)
 {
 	int flag, n_h = n_hit[seg_idx];
 	int this_tid = -1, this_pos = -1;
@@ -216,6 +300,7 @@ void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, i
 		if (r->rev) flag |= 0x10;
 		if (r->parent != r->id) flag |= 0x100;
 		else if (!r->sam_pri) flag |= 0x800;
+		if (r->qc_fail) flag |= 0x200; // set by mb_meth_apply_qc (chimera / set-as-failed)
 	}
 	if (n_seg > 1) {
 		if (r && r->proper_pair) flag |= 0x2;
@@ -230,11 +315,11 @@ void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, i
 	if (r == 0) {
 		if (r_prev) {
 			this_tid = r_prev->tid, this_pos = r_prev->ts;
-			kom_sprintf_lite(s, "\t%s\t%d\t0\t*", l2b->ctg[this_tid].name, this_pos+1);
+			kom_sprintf_lite(s, "\t%s\t%d\t0\t*", sam_ctg_name(l2b, cmap, this_tid), this_pos+1);
 		} else kom_sprintf_lite(s, "\t*\t0\t0\t*");
 	} else {
 		this_tid = r->tid, this_pos = r->ts;
-		kom_sprintf_lite(s, "\t%s\t%d\t%d\t", l2b->ctg[r->tid].name, r->ts+1, r->mapq);
+		kom_sprintf_lite(s, "\t%s\t%d\t%d\t", sam_ctg_name(l2b, cmap, r->tid), r->ts+1, r->mapq);
 		write_sam_cigar(s, flag, 0, t->l_seq, r, opt_flag);
 	}
 
@@ -242,17 +327,18 @@ void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, i
 	if (n_seg > 1) {
 		int tlen = 0;
 		if (this_tid >= 0 && r_next) {
-			if (this_tid == r_next->tid) {
-				if (r) {
+			// f<chr> + r<chr> mates collapse onto one output contig; require both CIGARs for TLEN
+			if (sam_same_output_tid(cmap, this_tid, r_next->tid)) {
+				if (r && r->p && r_next->p) {
 					int this_pos5 = r->rev? r->te - 1 : this_pos;
 					int next_pos5 = r_next->rev? r_next->te - 1 : r_next->ts;
 					tlen = next_pos5 - this_pos5;
 				}
 				kom_sprintf_lite(s, "\t=\t");
-			} else kom_sprintf_lite(s, "\t%s\t", l2b->ctg[r_next->tid].name);
+			} else kom_sprintf_lite(s, "\t%s\t", sam_ctg_name(l2b, cmap, r_next->tid));
 			kom_sprintf_lite(s, "%d\t", r_next->ts + 1);
 		} else if (r_next) { // && this_tid < 0
-			kom_sprintf_lite(s, "\t%s\t%d\t", l2b->ctg[r_next->tid].name, r_next->ts + 1);
+			kom_sprintf_lite(s, "\t%s\t%d\t", sam_ctg_name(l2b, cmap, r_next->tid), r_next->ts + 1);
 		} else if (this_tid >= 0) { // && r_next == NULL
 			kom_sprintf_lite(s, "\t=\t%d\t", this_pos + 1); // next segment will take r's coordinate
 		} else kom_sprintf_lite(s, "\t*\t0\t"); // neither has coordinates
@@ -261,22 +347,32 @@ void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, i
 		kom_sprintf_lite(s, "%d\t", tlen);
 	} else kom_sprintf_lite(s, "\t*\t0\t0\t");
 
+	// --meth: restore pre-c2t bases from YS:Z so callers see real C/T content (else c2t-projected)
+	const char *seq_src = t->seq;
+	int meth_seq = 0;
+	if (opt_flag & MB_F_METH) {
+		const char *o = meth_orig_seq(t);
+		if (o) seq_src = o, meth_seq = 1;
+	}
+	void (*write_sq)(kstring_t *, char *, int, int, int) =
+		meth_seq? sam_write_sq_upper : sam_write_sq;
+
 	// write SEQ and QUAL
 	if (r == 0) {
-		sam_write_sq(s, t->seq, t->l_seq, 0, 0);
+		write_sq(s, (char *)seq_src, t->l_seq, 0, 0);
 		kom_sprintf_lite(s, "\t");
 		if (t->qual) sam_write_sq(s, t->qual, t->l_seq, 0, 0);
 		else kom_sprintf_lite(s, "*");
 	} else {
 		if ((flag & 0x900) == 0 || (opt_flag & MB_F_SUPP_SOFT)) {
-			sam_write_sq(s, t->seq, t->l_seq, r->rev, r->rev);
+			write_sq(s, (char *)seq_src, t->l_seq, r->rev, r->rev);
 			kom_sprintf_lite(s, "\t");
 			if (t->qual) sam_write_sq(s, t->qual, t->l_seq, r->rev, 0);
 			else kom_sprintf_lite(s, "*");
 		} else if ((flag & 0x100) && !(opt_flag & MB_F_2ND_SEQ)){
 			kom_sprintf_lite(s, "*\t*");
 		} else {
-			sam_write_sq(s, t->seq + r->qs, r->qe - r->qs, r->rev, r->rev);
+			write_sq(s, (char *)seq_src + r->qs, r->qe - r->qs, r->rev, r->rev);
 			kom_sprintf_lite(s, "\t");
 			if (t->qual) sam_write_sq(s, t->qual + r->qs, r->qe - r->qs, r->rev, 0);
 			else kom_sprintf_lite(s, "*");
@@ -295,6 +391,16 @@ void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, i
 			kom_sprintf_lite(s, "\tMQ:i:%d", r_next->mapq);
 		}
 		if (r->p->cs) kom_sprintf_lite(s, "\t%s", (char*)&r->p->cigar[r->p->n_cigar]);
+		// YD:Z direction tag from cmap (or contig-name prefix as fallback when cmap is absent)
+		if ((opt_flag & MB_F_METH) && r->tid >= 0) {
+			char dir = 0;
+			if (cmap && r->tid < cmap->n_internal) dir = cmap->direction[r->tid];
+			if (dir == 0) {
+				const char *cname = l2b->ctg[r->tid].name;
+				if (cname && (cname[0] == 'f' || cname[0] == 'r')) dir = cname[0];
+			}
+			if (dir != 0) kom_sprintf_lite(s, "\tYD:Z:%c", dir);
+		}
 		if (r->parent == r->id && r->p && n_h > 1 && h && r >= h && r - h < n_h) { // supplementary aln may exist
 			int i, n_sa = 0; // n_sa: number of SA fields
 			for (i = 0; i < n_h; ++i)
@@ -310,7 +416,7 @@ void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, i
 					else l_M = q->te - q->ts, l_I = (q->qe - q->qs) - l_M;
 					clip5 = q->rev? t->l_seq - q->qe : q->qs;
 					clip3 = q->rev? q->qs : t->l_seq - q->qe;
-					kom_sprintf_lite(s, "%s,%d,%c,", l2b->ctg[q->tid].name, q->ts+1, "+-"[q->rev]);
+					kom_sprintf_lite(s, "%s,%d,%c,", sam_ctg_name(l2b, cmap, q->tid), q->ts+1, "+-"[q->rev]);
 					if (clip5) kom_sprintf_lite(s, "%dS", clip5);
 					if (l_M) kom_sprintf_lite(s, "%dM", l_M);
 					if (l_I) kom_sprintf_lite(s, "%dI", l_I);
@@ -323,15 +429,15 @@ void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, i
 	}
 
 	if ((opt_flag & MB_F_COPY_COMMENT) && t->comment)
-		kom_sprintf_lite(s, "\t%s", t->comment);
+		sam_write_comment(s, t->comment, !!(opt_flag & MB_F_METH));
 	kom_sprintf_lite(s, "\n");
 	s->s[s->l] = 0; // we always have room for an extra byte
 }
 
-void mb_format(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx, int32_t mate_qlen)
+void mb_format(void *km, kstring_t *s, const l2b_t *l2b, const mb_meth_cmap_t *cmap, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx, int32_t mate_qlen)
 {
 	if (opt_flag & MB_F_SAM)
-		mb_fmt_sam(km, s, l2b, t, n_seg, n_hit, hit, hit_idx, opt_flag, seg_idx, mate_qlen);
+		mb_fmt_sam(km, s, l2b, cmap, t, n_seg, n_hit, hit, hit_idx, opt_flag, seg_idx, mate_qlen);
 	else
 		mb_fmt_paf(s, l2b, t, hit_idx >= 0? &hit[seg_idx][hit_idx] : 0, opt_flag, n_seg, seg_idx);
 }

--- a/index.c
+++ b/index.c
@@ -1,12 +1,109 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <zlib.h>
 #include "libsais64.h"
 #include "kommon.h"
 #include "ketopt.h"
 #include "mbpriv.h"
+#include "kseq.h"
+KSEQ_DECLARE(gzFile)
 
 void mb_bwtgen(const char *fn_pac, const char *fn_bwt, int block_size);
+
+// --meth: write doubled c2t FASTA (>r<name> G->A, >f<name> C->T) next to <fa>.
+// Format: uppercased, 100bp wrap. Skipped if <fa>.bwameth.c2t is fresher than <fa>.
+
+static void meth_project_and_write(FILE *out, const char *prefix, const char *name,
+                                   const char *seq, size_t len, char from, char to)
+{
+	char buf[65536];
+	size_t bl = 0, i;
+	fprintf(out, ">%s%s\n", prefix, name);
+	for (i = 0; i < len; ++i) {
+		if (bl + 2 > sizeof(buf)) { fwrite(buf, 1, bl, out); bl = 0; }
+		char c = seq[i];
+		buf[bl++] = (c == from) ? to : c;
+		if (((i + 1) % 100) == 0) buf[bl++] = '\n';
+	}
+	if (len % 100 != 0) {
+		if (bl + 1 > sizeof(buf)) { fwrite(buf, 1, bl, out); bl = 0; }
+		buf[bl++] = '\n';
+	}
+	if (bl) fwrite(buf, 1, bl, out);
+}
+
+static int meth_c2t_is_fresh(const char *in_fa, const char *out_fa)
+{
+	struct stat a, b;
+	if (stat(in_fa, &a) != 0 || stat(out_fa, &b) != 0) return 0;
+	return b.st_mtime > a.st_mtime; // strict: same mtime (1s resolution) means rebuild
+}
+
+static int meth_write_c2t_fasta(const char *fa, char *out_fa, size_t out_fa_cap)
+{
+	int n = snprintf(out_fa, out_fa_cap, "%s.bwameth.c2t", fa);
+	if (n <= 0 || (size_t)n >= out_fa_cap) {
+		if (kom_verbose >= 1) fprintf(stderr, "ERROR: reference path too long\n");
+		return 1;
+	}
+	if (meth_c2t_is_fresh(fa, out_fa)) {
+		if (kom_verbose >= 2)
+			fprintf(stderr, "[index:--meth] %s is newer than %s; skipping c2t FASTA emission\n",
+			        out_fa, fa);
+		return 0;
+	}
+	gzFile in = gzopen(fa, "r");
+	if (in == 0) {
+		if (kom_verbose >= 1) fprintf(stderr, "ERROR: cannot open %s\n", fa);
+		return 2;
+	}
+	FILE *out = fopen(out_fa, "w");
+	if (out == 0) {
+		if (kom_verbose >= 1) fprintf(stderr, "ERROR: cannot open %s for writing\n", out_fa);
+		gzclose(in);
+		return 3;
+	}
+	if (kom_verbose >= 2) fprintf(stderr, "[index:--meth] writing %s ...\n", out_fa);
+
+	kseq_t *seq = kseq_init(in);
+	int64_t total_bases = 0, n_seqs = 0;
+	int kr = 0;
+	while ((kr = kseq_read(seq)) >= 0) {
+		size_t i;
+		// upper-case before projection (soft-masked input round-trips like bwameth.py)
+		for (i = 0; i < seq->seq.l; ++i) {
+			char c = seq->seq.s[i];
+			if (c >= 'a' && c <= 'z') seq->seq.s[i] = (char)(c - 'a' + 'A');
+		}
+		meth_project_and_write(out, "r", seq->name.s, seq->seq.s, seq->seq.l, 'G', 'A');
+		meth_project_and_write(out, "f", seq->name.s, seq->seq.s, seq->seq.l, 'C', 'T');
+		total_bases += (int64_t)seq->seq.l;
+		++n_seqs;
+	}
+	kseq_destroy(seq);
+	gzclose(in);
+	// kseq_read: -1 = EOF, < -1 = parse/IO error; drop partial file so freshness check rebuilds
+	if (kr < -1) {
+		fclose(out);
+		unlink(out_fa);
+		if (kom_verbose >= 1)
+			fprintf(stderr, "ERROR: failed while reading %s (kseq_read=%d)\n", fa, kr);
+		return 4;
+	}
+	if (fclose(out) != 0) {
+		unlink(out_fa);
+		if (kom_verbose >= 1) fprintf(stderr, "ERROR: failed to close %s\n", out_fa);
+		return 4;
+	}
+	if (kom_verbose >= 2)
+		fprintf(stderr, "[index:--meth] emitted %ld seqs, %ld bp (doubled to %ld bp of c2t text)\n",
+		        (long)n_seqs, (long)total_bases, (long)(2 * total_bases));
+	return 0;
+}
 
 static mb_bwt_t *mb_bwt_libsais(const l2b_t *l2b, int sa_bit, int both_strand, int n_thread)
 {
@@ -230,6 +327,9 @@ static int usage_index(FILE *fp, uint64_t seed, int sa_bit, int n_thread)
 #ifdef LIBSAIS_OPENMP
 	fprintf(fp, "  -t INT    number of threads (effective w/o -l) [%d]\n", n_thread);
 #endif
+	fprintf(fp, "  --meth    build a bwameth-style doubled c2t reference (writes\n");
+	fprintf(fp, "            <in.fasta>.bwameth.c2t and indexes that). Use with\n");
+	fprintf(fp, "            `minibwa map --meth <in.fasta> R1.fq [R2.fq]`.\n");
 	fprintf(fp, "  --help    print this help message\n");
 	return fp == stdout? 0 : 1;
 }
@@ -237,14 +337,17 @@ static int usage_index(FILE *fp, uint64_t seed, int sa_bit, int n_thread)
 int main_index(int argc, char *argv[])
 {
 	ketopt_t o = KETOPT_INIT;
-	int c, low_mem = 0, n_thread = 4, sa_bit = 4;
+	int c, low_mem = 0, n_thread = 4, sa_bit = 4, meth = 0;
 	int64_t block_size = 10000000;
 	uint64_t seed = 11;
 	char *prefix, *fn_l2b, *fn_bwt;
+	const char *fa_in;
+	char meth_c2t_path[4096];
 	l2b_t *l2b;
 	mb_bwt_t *bwt;
 	static ko_longopt_t long_opts[] = {
 		{ "help", ko_no_argument, 901 },
+		{ "meth", ko_no_argument, 1000 },
 		{ 0, 0, 0 }
 	};
 
@@ -255,16 +358,32 @@ int main_index(int argc, char *argv[])
 		else if (c == 'u') sa_bit = atoi(o.arg);
 		else if (c == 's') seed = atol(o.arg);
 		else if (c == 901) return usage_index(stdout, seed, sa_bit, n_thread);
+		else if (c == 1000) meth = 1;
 	}
 	if (argc - o.ind == 0) return usage_index(stderr, seed, sa_bit, n_thread);
 
-	prefix = o.ind + 1 < argc? argv[o.ind+1] : argv[o.ind];
+	fa_in = argv[o.ind];
+	if (meth) {
+		/* Reject -p / explicit out-prefix for --meth: the c2t flow is
+		 * keyed off "<in.fasta>.bwameth.c2t" both at index time and at
+		 * map time, and silently overriding it would only confuse. */
+		if (o.ind + 1 < argc) {
+			if (kom_verbose >= 1)
+				fprintf(stderr, "ERROR: --meth does not accept an explicit out-prefix (use bare <in.fasta>)\n");
+			return 1;
+		}
+		int rc = meth_write_c2t_fasta(fa_in, meth_c2t_path, sizeof(meth_c2t_path));
+		if (rc != 0) return rc;
+		fa_in = meth_c2t_path; /* index the doubled FASTA */
+	}
+
+	prefix = (!meth && o.ind + 1 < argc) ? argv[o.ind+1] : (char *)fa_in;
 	fn_l2b = kom_calloc(char, strlen(prefix) + 5);
 	strcat(strcpy(fn_l2b, prefix), ".l2b");
 	fn_bwt = kom_calloc(char, strlen(prefix) + 5);
 	strcat(strcpy(fn_bwt, prefix), ".mbw");
 
-	l2b = l2b_import(argv[o.ind], seed);
+	l2b = l2b_import(fa_in, seed);
 	kom_assert(l2b, "failed to read the genome FASTA.");
 	if (low_mem) {
 #ifdef USE_GPL

--- a/map-algo.c
+++ b/map-algo.c
@@ -640,7 +640,7 @@ mb_hit_t *mb_map(const mb_opt_t *opt, const mb_idx_t *idx, int32_t qlen, const c
 	seq = Kmalloc(b->km, uint8_t, qlen);
 	for (i = 0; i < qlen; ++i)
 		seq[i] = kom_nt4_table[(uint8_t)seq0[i]];
-	mb_seed_intv(b->km, idx->bwt, qlen, seq, opt->min_len, opt->max_sub_occ, &u);
+	mb_seed_intv(b->km, idx->bwt, qlen, seq, opt->min_len, opt->max_sub_occ, opt->min_sub_occ, &u);
 	ret = mb_map_sai(&opt_adap, idx, qlen, seq, &u, n_hit_, b, qname);
 	kfree(b->km, seq);
 	if (b0 == 0) mb_tbuf_destroy(b);
@@ -682,7 +682,7 @@ mb_hit_t **mb_map_batch(const mb_opt_t *opt, const mb_idx_t *idx, int32_t n_seq,
 
 			// batch SMEM for sub-batch
 			memset(sai, 0, sb_n * sizeof(mb_sai_v));
-			mb_seed_intv_batch(km, idx->bwt, sb_n, &qlen[sb_st], seq4, opt->min_len, opt->max_sub_occ, sai);
+			mb_seed_intv_batch(km, idx->bwt, sb_n, &qlen[sb_st], seq4, opt->min_len, opt->max_sub_occ, opt->min_sub_occ, sai);
 
 			// map each sequence in sub-batch
 			for (k = 0; k < sb_n; ++k) {

--- a/map-algo.c
+++ b/map-algo.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <math.h>
 #include "mbpriv.h"
+#include "meth.h"
 #include "kalloc.h"
 #include "kommon.h"
 #include "ksort.h"
@@ -705,6 +706,8 @@ mb_hit_t **mb_map_batch(const mb_opt_t *opt, const mb_idx_t *idx, int32_t n_seq,
 	// paired-end processing
 	if (is_pe && n_seq >= 2) {
 		mb_pestat_t pes[4];
+		/* Build cmap on demand for --meth so batch-API callers get cross-contig pairing/rescue. */
+		mb_meth_cmap_t *cmap_local = (opt->flag & MB_F_METH)? mb_meth_cmap_build(idx->l2b) : 0;
 		for (i = 0; i < 4; ++i) pes[i].failed = 1;
 		pes[1].failed = 0;
 		pes[1].avg = opt->pe_avg, pes[1].std = opt->pe_std;
@@ -712,8 +715,9 @@ mb_hit_t **mb_map_batch(const mb_opt_t *opt, const mb_idx_t *idx, int32_t n_seq,
 		for (i = 0; i + 1 < n_seq; i += 2) {
 			int32_t len2[2] = { qlen[i], qlen[i+1] };
 			char *seq2[2] = { (char*)seq[i], (char*)seq[i+1] };
-			mb_pair(km, opt, idx->l2b, &n_hit[i], &hit[i], pes, len2, seq2);
+			mb_pair(km, opt, idx->l2b, cmap_local, &n_hit[i], &hit[i], pes, len2, seq2);
 		}
+		mb_meth_cmap_free(cmap_local);
 	}
 
 	if (b0 == 0) mb_tbuf_destroy(b);

--- a/map-main.c
+++ b/map-main.c
@@ -93,7 +93,7 @@ static void worker_for_pe(void *data, long i, int tid)
 		seq[r] = s->seq[off + r].seq;
 		len[r] = s->seq[off + r].l_seq;
 	}
-	mb_pair(mb_tbuf_km(b), s->p->opt, s->p->idx->l2b, &s->n_hit[off], &s->hit[off], s->pes, len, seq);
+	mb_pair(mb_tbuf_km(b), s->p->opt, s->p->idx->l2b, s->p->cmap, &s->n_hit[off], &s->hit[off], s->pes, len, seq);
 }
 
 static void *worker_pipeline(void *shared, int step, void *in)
@@ -174,7 +174,7 @@ static void *worker_pipeline(void *shared, int step, void *in)
 			} else { // estimate PE stats from data
 				void *km;
 				km = opt->flag & MB_F_NO_KALLOC? 0 : km_init();
-				mb_pestat(km, opt, s->n_frag, s->seg_off, s->seg_cnt, s->n_hit, s->hit, s->pes);
+				mb_pestat(km, opt, s->p->cmap, s->n_frag, s->seg_off, s->seg_cnt, s->n_hit, s->hit, s->pes);
 				if (km) km_destroy(km);
 			}
 			kt_for(opt->n_thread, worker_for_pe, in, s->n_frag);
@@ -295,7 +295,7 @@ static ko_longopt_t long_options[] = {
 	{ "adap",         ko_required_argument, 308 },
 	{ "chain-only",   ko_no_argument,       309 },
 	{ "max-sub-occ",  ko_required_argument, 310 }, // ablation: 0 disables Pass-2 sub-SMEM reseeding
-	{ "min-sub-occ",  ko_required_argument, 311 }, // ablation: skip Pass-2 for SMEMs with SA-interval size < N (default 1)
+	{ "min-sub-occ", ko_required_argument, 311 }, // ablation: skip Pass-2 for SMEMs with size < N (default 1)
 	{ "dbg-aln-seq",  ko_no_argument,       601 },
 	{ "dbg-anchor",   ko_no_argument,       602 },
 	{ "dbg-seed",     ko_no_argument,       603 },
@@ -452,7 +452,7 @@ int main_map(int argc, char *argv[])
 			mo.flag |= MB_F_NO_ALN;
 		} else if (c == 310) { // --max-sub-occ
 			mo.max_sub_occ = atoi(o.arg);
-		} else if (c == 311) { // --min-sub-occ
+		} else if (c == 311) { // --min-sub-size
 			mo.min_sub_occ = atoi(o.arg);
 		} else if (c == 601) { // --dbg-aln-seq
 			kom_dbg_flag |= MB_DBG_ALN_SEQ;

--- a/map-main.c
+++ b/map-main.c
@@ -16,6 +16,7 @@ typedef struct {
 	const mb_opt_t *opt;
 	mb_bseq_file_t **fp;
 	const mb_idx_t *idx;
+	const mb_meth_cmap_t *cmap; // bisulfite chrom-consolidation map; NULL outside --meth
 	FILE *fp_out;
 } pipeline_t;
 
@@ -103,7 +104,7 @@ static void *worker_pipeline(void *shared, int step, void *in)
 	const mb_opt_t *opt = p->opt;
     if (step == 0) { // step 0: read sequences
 		int with_qual = !!(opt->flag & MB_F_SAM);
-		int with_comment = !!(opt->flag & MB_F_COPY_COMMENT);
+		int with_comment = !!(opt->flag & MB_F_COPY_COMMENT); // --meth implies MB_F_COPY_COMMENT (set in main_map)
 		int frag_mode = (p->n_fp > 1 || !!(opt->flag & MB_F_PE));
         step_t *s;
         s = kom_calloc(step_t, 1);
@@ -115,6 +116,8 @@ static void *worker_pipeline(void *shared, int step, void *in)
 			for (i = 0; i < 4; ++i) s->pes[i].failed = 1;
 			for (i = 0; i < s->n_seq; ++i)
 				s->seq[i].id = p->n_seq++;
+			if (opt->flag & MB_F_METH)
+				mb_meth_ingest(s->n_seq, s->seq, frag_mode, p->n_fp > 1);
 			s->tbuf = kom_calloc(mb_tbuf_t*, opt->n_thread);
 			for (i = 0; i < opt->n_thread; ++i)
 				s->tbuf[i] = mb_tbuf_init(opt->flag&MB_F_NO_KALLOC);
@@ -192,6 +195,9 @@ static void *worker_pipeline(void *shared, int step, void *in)
 		for (k = 0; k < s->n_frag; ++k) {
 			int32_t seg_st = s->seg_off[k], seg_en = s->seg_off[k] + s->seg_cnt[k];
 			out.l = 0;
+			if (opt->flag & MB_F_METH) // chimera QC must run before mb_format reads qc_fail/proper_pair
+				mb_meth_apply_qc(opt, p->cmap, &s->seq[seg_st], seg_en - seg_st,
+				                 &s->n_hit[seg_st], &s->hit[seg_st]);
 			for (i = seg_st; i < seg_en; ++i) {
 				mb_bseq1_t *t = &s->seq[i];
 				int32_t mate_qlen = 0; // mate's l_seq for MC:Z; 0 suppresses MC/MQ
@@ -205,11 +211,11 @@ static void *worker_pipeline(void *shared, int step, void *in)
 					for (j = 0; j < s->n_hit[i]; ++j) {
 						const mb_hit_t *h = &s->hit[i][j];
 						if (h->parent == h->id || n_sec < opt->out_n)
-							mb_format(km, &out, idx->l2b, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], j, opt->flag, i - seg_st, mate_qlen);
+							mb_format(km, &out, idx->l2b, p->cmap, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], j, opt->flag, i - seg_st, mate_qlen);
 						n_sec += (h->parent != h->id);
 					}
 				} else if (!(opt->flag & MB_F_NO_UNMAP)) { // TODO: output unmapped reads
-					mb_format(km, &out, idx->l2b, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], -1, opt->flag, i - seg_st, mate_qlen);
+					mb_format(km, &out, idx->l2b, p->cmap, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], -1, opt->flag, i - seg_st, mate_qlen);
 				}
 			}
 			fwrite(out.s, 1, out.l, s->p->fp_out);
@@ -250,7 +256,7 @@ static mb_bseq_file_t **mb_open_bseqs(int n, const char **fn)
 	return fp;
 }
 
-int32_t mb_map_file(const mb_opt_t *opt, const mb_idx_t *idx, int32_t n, const char **fn, const char *fn_out)
+int32_t mb_map_file(const mb_opt_t *opt, const mb_idx_t *idx, const mb_meth_cmap_t *cmap, int32_t n, const char **fn, const char *fn_out)
 {
 	int32_t i, pl_thread;
 	pipeline_t pl;
@@ -261,7 +267,7 @@ int32_t mb_map_file(const mb_opt_t *opt, const mb_idx_t *idx, int32_t n, const c
 	pl.n_fp = n;
 	pl.fp = mb_open_bseqs(pl.n_fp, fn);
 	if (pl.fp == 0) return -1;
-	pl.opt = opt, pl.idx = idx;
+	pl.opt = opt, pl.idx = idx, pl.cmap = cmap;
 	pl.mb_size = opt->mb_size;
 	pl_thread = opt->n_thread <= 2? opt->n_thread : 3;
 
@@ -294,6 +300,9 @@ static ko_longopt_t long_options[] = {
 	{ "dbg-qname",    ko_no_argument,       604 },
 	{ "dbg-aln-pe",   ko_no_argument,       605 },
 	{ "dbg-an-pos",   ko_no_argument,       606 }, // anchor position
+	{ "meth",                     ko_no_argument,       701 },
+	{ "set-as-failed",            ko_required_argument, 702 }, // 'f' or 'r' — flag matching-strand reads
+	{ "do-not-penalize-chimeras", ko_no_argument,       703 }, // disable longest-M chimera heuristic
 	{ "version",      ko_no_argument,       901 },
 	{ "help",         ko_no_argument,       902 },
 	{ 0, 0, 0 }
@@ -331,11 +340,15 @@ static int usage(FILE *fp, const mb_opt_t *opt)
 	fprintf(fp, "  Paired-end:\n");
 	fprintf(fp, "    -P               skip pairing and mate resuce\n");
 	fprintf(fp, "    --rescue=INT     mate rescue for up to INT candidates; 0 to skip rescue [%d]\n", opt->max_rescue);
+	fprintf(fp, "  Bisulfite (methylation):\n");
+	fprintf(fp, "    --meth                          enable bisulfite mode\n");
+	fprintf(fp, "    --set-as-failed=f|r             flag matching-strand reads with 0x200\n");
+	fprintf(fp, "    --do-not-penalize-chimeras      skip the longest-M chimera heuristic\n");
 	fprintf(fp, "  Input/Output:\n");
 	fprintf(fp, "    -o FILE          output file name [stdout]\n");
 	fprintf(fp, "    -u               don't output unmapped reads\n");
 	fprintf(fp, "    --outn=INT       output up to INT secondary alignments [0]\n");
-	fprintf(fp, "    -y               copy FASTA/Q comments to output\n");
+	fprintf(fp, "    -y               copy SAM-tag-formatted FASTA/Q comment segments to output\n");
 	fprintf(fp, "    -Y               use soft clipping for supplementary alignments\n");
 	fprintf(fp, "    -K NUM1[,NUM2]   process NUM1-NUM2 bp of query sequences in a batch [100m,1g]\n");
 	fprintf(fp, "    --version        print version number\n");
@@ -402,10 +415,14 @@ int main_map(int argc, char *argv[])
 		else if (c == 's') mo.min_dp_max = atoi(o.arg);
 		else if (c == 'L') {
 			char *p = NULL;
-			long v = strtol(o.arg, &p, 10);
-			mo.pen_clip5 = mo.pen_clip3 = (int32_t)v;
-			if (p && *p == ',')
-				mo.pen_clip3 = (int32_t)strtol(p + 1, NULL, 10);
+			mo.pen_clip5 = mo.pen_clip3 = (int32_t)strtol(o.arg, &p, 10);
+			if (p == o.arg || (*p != 0 && *p != ',')) goto bad_L;
+			if (*p == ',') {
+				char *q = NULL;
+				mo.pen_clip3 = (int32_t)strtol(p + 1, &q, 10);
+				if (q == p + 1 || *q != 0) goto bad_L;
+			}
+			if (0) { bad_L: fprintf(stderr, "[ERROR] malformed -L: %s\n", o.arg); return 1; }
 		}
 		else if (c == 'o') fn_out = o.arg;
 		else if (c == 't') mo.n_thread = atoi(o.arg);
@@ -441,6 +458,21 @@ int main_map(int argc, char *argv[])
 			kom_dbg_flag |= MB_DBG_ALN_PE;
 		} else if (c == 606) { // --dbg-an-pos
 			kom_dbg_flag |= MB_DBG_AN_POS;
+		} else if (c == 701) { // --meth
+			mo.flag |= MB_F_METH | MB_F_COPY_COMMENT;
+			// match bwameth.py's `bwa mem -T 40 -B 2 -A 1`; pen_clip / end_bonus / min_chain_score = bwa-mem defaults
+			mo.a = 1, mo.b = 2, mo.min_dp_max = 40;
+			mo.pen_clip5 = mo.pen_clip3 = 5;
+			mo.end_bonus = 5;
+			mo.min_chain_score = 10;
+		} else if (c == 702) { // --set-as-failed=f|r
+			if (o.arg == 0 || (o.arg[0] != 'f' && o.arg[0] != 'r') || o.arg[1] != '\0') {
+				fprintf(stderr, "[ERROR] --set-as-failed expects 'f' or 'r'\n");
+				return 1;
+			}
+			mo.meth_set_as_failed = o.arg[0];
+		} else if (c == 703) { // --do-not-penalize-chimeras
+			mo.meth_no_chim = 1;
 		} else if (c == 'K') {
 			mo.mb_size = mo.max_mb_size = kom_parse_num(o.arg, &s);
 			if (*s == ',') mo.max_mb_size = kom_parse_num(s + 1, &s);
@@ -471,21 +503,45 @@ int main_map(int argc, char *argv[])
 	if (argc - o.ind < 2)
 		return usage(stderr, &mo);
 
-	idx = mb_idx_load(argv[o.ind]);
+	// --meth: auto-append ".bwameth.c2t" if the user passed the bare reference
+	char meth_ref_buf[4096];
+	const char *ref_prefix = argv[o.ind];
+	if (mo.flag & MB_F_METH) {
+		const char *suffix = ".bwameth.c2t";
+		size_t slen = strlen(suffix);
+		size_t alen = strlen(argv[o.ind]);
+		int already_c2t = (alen >= slen) &&
+			(strcmp(argv[o.ind] + alen - slen, suffix) == 0);
+		if (!already_c2t) {
+			int n = snprintf(meth_ref_buf, sizeof(meth_ref_buf), "%s%s", argv[o.ind], suffix);
+			if (n <= 0 || (size_t)n >= sizeof(meth_ref_buf)) {
+				fprintf(stderr, "[ERROR] reference path too long for --meth\n");
+				return 1;
+			}
+			ref_prefix = meth_ref_buf;
+			if (kom_verbose >= 3)
+				fprintf(stderr, "[M::%s] --meth: resolved index prefix to %s\n", __func__, ref_prefix);
+		}
+	}
+
+	idx = mb_idx_load(ref_prefix);
 	kom_assert(idx, "failed to load the index.");
 	if (kom_verbose >= 3)
 		fprintf(stderr, "[M::%s::%.3f*%.2f] index loaded\n", __func__, kom_realtime(), kom_percent_cpu());
 
+	mb_meth_cmap_t *cmap = (mo.flag & MB_F_METH)? mb_meth_cmap_build(idx->l2b) : 0;
+
 	if (mo.flag & MB_F_SAM) {
 		int ret;
 		kstring_t out = {0,0,0};
-		ret = mb_fmt_sam_hdr(&out, idx->l2b, rg_line, MB_VERSION, argc, argv);
-		if (ret < 0) return 1; // TODO: free idx and out.s
+		ret = mb_fmt_sam_hdr(&out, idx->l2b, cmap, rg_line, MB_VERSION, argc, argv);
+		if (ret < 0) { mb_meth_cmap_free(cmap); mb_idx_destroy(idx); return 1; }
 		fwrite(out.s, 1, out.l, stdout);
 		free(out.s);
 	}
 
-	mb_map_file(&mo, idx, argc - (o.ind + 1), (const char**)&argv[o.ind+1], fn_out);
+	mb_map_file(&mo, idx, cmap, argc - (o.ind + 1), (const char**)&argv[o.ind+1], fn_out);
+	mb_meth_cmap_free(cmap);
 	mb_idx_destroy(idx);
 	return 0;
 }

--- a/map-main.c
+++ b/map-main.c
@@ -327,6 +327,7 @@ static int usage(FILE *fp, const mb_opt_t *opt)
 	fprintf(fp, "    -O INT1[,INT2]   gap open penalty [%d,%d]\n", opt->q, opt->q2);
 	fprintf(fp, "    -E INT1[,INT2]   gap extension penalty [%d,%d]\n", opt->e, opt->e2);
 	fprintf(fp, "    -s INT           suppress alignment with DP score lower than INT*{-A} [%d]\n", opt->min_dp_max);
+	fprintf(fp, "    -L INT[,INT]     5'/3' soft-clip penalty (extend through noisy ends if `mqe + end_bonus + L >= max`) [%d,%d]\n", opt->pen_clip5, opt->pen_clip3);
 	fprintf(fp, "  Paired-end:\n");
 	fprintf(fp, "    -P               skip pairing and mate resuce\n");
 	fprintf(fp, "    --rescue=INT     mate rescue for up to INT candidates; 0 to skip rescue [%d]\n", opt->max_rescue);
@@ -357,7 +358,7 @@ static inline void yes_or_no(mb_opt_t *opt, uint64_t flag, int long_idx, const c
 
 int main_map(int argc, char *argv[])
 {
-	const char *opt_str = "x:o:k:c:m:p:A:B:b:O:E:t:K:N:PyYR:aul:w:W:g:5s:";
+	const char *opt_str = "x:o:k:c:m:p:A:B:b:O:E:L:t:K:N:PyYR:aul:w:W:g:5s:";
 	int32_t c;
 	mb_idx_t *idx;
 	mb_opt_t mo;
@@ -399,6 +400,13 @@ int main_map(int argc, char *argv[])
 		else if (c == '5') mo.flag |= MB_F_PRIMARY5;
 		else if (c == 'P') mo.flag |= MB_F_NO_PAIRING;
 		else if (c == 's') mo.min_dp_max = atoi(o.arg);
+		else if (c == 'L') {
+			char *p = NULL;
+			long v = strtol(o.arg, &p, 10);
+			mo.pen_clip5 = mo.pen_clip3 = (int32_t)v;
+			if (p && *p == ',')
+				mo.pen_clip3 = (int32_t)strtol(p + 1, NULL, 10);
+		}
 		else if (c == 'o') fn_out = o.arg;
 		else if (c == 't') mo.n_thread = atoi(o.arg);
 		else if (c == 'R') rg_line = o.arg;

--- a/map-main.c
+++ b/map-main.c
@@ -61,7 +61,7 @@ static void worker_for_se_batch(void *data, long i, int tid)
 		}
 	}
 	assert(p == n);
-	mb_seed_intv_batch(km, idx->bwt, n, len, seq, opt->min_len, opt->max_sub_occ, sai);
+	mb_seed_intv_batch(km, idx->bwt, n, len, seq, opt->min_len, opt->max_sub_occ, opt->min_sub_occ, sai);
 	for (k = p = 0; k < s->sb_cnt[i]; ++k) {
 		int32_t off = s->seg_off[s->sb_off[i] + k];
 		int32_t cnt = s->seg_cnt[s->sb_off[i] + k];
@@ -294,6 +294,8 @@ static ko_longopt_t long_options[] = {
 	{ "long",         ko_optional_argument, 307 },
 	{ "adap",         ko_required_argument, 308 },
 	{ "chain-only",   ko_no_argument,       309 },
+	{ "max-sub-occ",  ko_required_argument, 310 }, // ablation: 0 disables Pass-2 sub-SMEM reseeding
+	{ "min-sub-occ",  ko_required_argument, 311 }, // ablation: skip Pass-2 for SMEMs with SA-interval size < N (default 1)
 	{ "dbg-aln-seq",  ko_no_argument,       601 },
 	{ "dbg-anchor",   ko_no_argument,       602 },
 	{ "dbg-seed",     ko_no_argument,       603 },
@@ -329,6 +331,8 @@ static int usage(FILE *fp, const mb_opt_t *opt)
 	fprintf(fp, "    -p FLOAT         min secondary-to-primary score ratio [%g]\n", opt->pri_ratio);
 	fprintf(fp, "    -N INT           retain at most INT secondary alignments [%d]\n", opt->best_n);
 	fprintf(fp, "    --chain-only     perform chaining only without base alignment\n");
+	fprintf(fp, "    --max-sub-occ=INT  reseed Pass-2 sub-SMEMs only when SA-interval size <= INT (0 disables Pass-2) [%d]\n", opt->max_sub_occ);
+	fprintf(fp, "    --min-sub-occ=INT  skip Pass-2 reseeding when SA-interval size < INT [%d]\n", opt->min_sub_occ);
 	fprintf(fp, "    -x STR           preset (sr, lr or adap for mixed short/long reads) [adap]\n");
 	fprintf(fp, "  Alignment:\n");
 	fprintf(fp, "    -A INT           matching score [%d]\n", opt->a);
@@ -446,6 +450,10 @@ int main_map(int argc, char *argv[])
 			yes_or_no(&mo, MB_F_ADAP, o.longidx, o.arg, 1);
 		} else if (c == 309) { // --chain-only
 			mo.flag |= MB_F_NO_ALN;
+		} else if (c == 310) { // --max-sub-occ
+			mo.max_sub_occ = atoi(o.arg);
+		} else if (c == 311) { // --min-sub-occ
+			mo.min_sub_occ = atoi(o.arg);
 		} else if (c == 601) { // --dbg-aln-seq
 			kom_dbg_flag |= MB_DBG_ALN_SEQ;
 		} else if (c == 602) { // --dbg-anchor

--- a/mbpriv.h
+++ b/mbpriv.h
@@ -97,8 +97,8 @@ void mb_append_cigar(mb_hit_t *r, uint32_t n_cigar, const uint32_t *cigar);
 void mb_update_extra(void *km, mb_hit_t *r, const uint8_t *qseq, const uint8_t *tseq, const int8_t *mat, int8_t q, int8_t e, uint64_t opt_flag, int log_gap);
 
 // defined in pe.c
-void mb_pestat(void *km, const mb_opt_t *opt, int32_t n_seg, const int32_t *seg_off, const int32_t *seg_cnt, const int32_t *n_hit, mb_hit_t *const *hit, mb_pestat_t pes[4]);
-void mb_pair(void *km, const mb_opt_t *opt, const l2b_t *l2b, int32_t n_hit[2], mb_hit_t *hit[2], const mb_pestat_t pes[4], int32_t qlen[2], char *const qseq[2]);
+void mb_pestat(void *km, const mb_opt_t *opt, const mb_meth_cmap_t *cmap, int32_t n_seg, const int32_t *seg_off, const int32_t *seg_cnt, const int32_t *n_hit, mb_hit_t *const *hit, mb_pestat_t pes[4]);
+void mb_pair(void *km, const mb_opt_t *opt, const l2b_t *l2b, const mb_meth_cmap_t *cmap, int32_t n_hit[2], mb_hit_t *hit[2], const mb_pestat_t pes[4], int32_t qlen[2], char *const qseq[2]);
 
 // Fast log2 approximation (from minimap2)
 static inline float mb_log2(float x) // NB: this doesn't work when x<2

--- a/mbpriv.h
+++ b/mbpriv.h
@@ -6,6 +6,7 @@
 #include "bwt.h"
 #include "kommon.h"
 #include "bseq.h"
+#include "meth.h"
 
 #define MB_DBG_ALN_SEQ     (0x1LL)
 #define MB_DBG_ANCHOR      (0x2LL)
@@ -87,8 +88,8 @@ void mb_write_MD(void *km, kstring_t *s, const uint8_t *tseq, const uint8_t *qse
 
 // defined in format.c
 void mb_fmt_paf(kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, const mb_hit_t *p, uint64_t opt_flag, int n_seg, int seg_idx);
-int mb_fmt_sam_hdr(kstring_t *str, const l2b_t *idx, const char *rg, const char *ver, int argc, char *argv[]);
-void mb_format(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx, int32_t mate_qlen);
+int mb_fmt_sam_hdr(kstring_t *str, const l2b_t *idx, const mb_meth_cmap_t *cmap, const char *rg, const char *ver, int argc, char *argv[]);
+void mb_format(void *km, kstring_t *s, const l2b_t *l2b, const mb_meth_cmap_t *cmap, const mb_bseq1_t *t, int32_t n_seg, const int32_t *n_hit, mb_hit_t *const*hit, int32_t hit_idx, int64_t opt_flag, int seg_idx, int32_t mate_qlen);
 
 // defined in align.c
 mb_hit_t *mb_align_skeleton(void *km, const mb_opt_t *opt, const mb_idx_t *mi, int qlen, const uint8_t *seq, int *n_regs_, mb_hit_t *regs, mb_anchor_t *a);

--- a/mbpriv.h
+++ b/mbpriv.h
@@ -53,8 +53,8 @@ void mb_opt_adap(const mb_opt_t *opt0, int32_t len, mb_opt_t *opt);
 void mb_bwtgen(const char *fn_pac, const char *fn_bwt, int block_size);
 
 // defined in seed.c
-void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq, int32_t min_len, int32_t max_sub_occ, mb_sai_v *v);
-void mb_seed_intv_batch(void *km, const mb_bwt_t *bwt, int32_t n_seq, const int32_t *len, uint8_t *const* seq, int32_t min_len, int32_t max_sub_occ, mb_sai_v *v);
+void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq, int32_t min_len, int32_t max_sub_occ, int32_t min_sub_occ, mb_sai_v *v);
+void mb_seed_intv_batch(void *km, const mb_bwt_t *bwt, int32_t n_seq, const int32_t *len, uint8_t *const* seq, int32_t min_len, int32_t max_sub_occ, int32_t min_sub_occ, mb_sai_v *v);
 void mb_anchor(void *km, const mb_idx_t *idx, mb_sai_v *u, int32_t qlen, int32_t max_occ, mb_anchor_v *v);
 void mb_anchor_sort(const l2b_t *l2b, int64_t n_a, mb_anchor_t *a);
 

--- a/meth.c
+++ b/meth.c
@@ -8,11 +8,16 @@
 #include "meth.h"
 
 /* Strip leading 'f'/'r' c2t prefix; collapse paired f<x>/r<x> contigs onto a
- * single output name; non-prefixed contigs pass through with direction 0. */
+ * single output name; non-prefixed contigs pass through with direction 0.
+ * canon_tid (lowest internal tid sharing out_tid) and paired_tid (the partner
+ * internal tid, or -1) are populated in the same pass via the existing
+ * out_tid lookup; once 3+ internal tids share an out_tid, all paired_tid
+ * entries for that group are pinned to -1 (ambiguous; no cross-contig rescue). */
 mb_meth_cmap_t *mb_meth_cmap_build(const l2b_t *l2b)
 {
 	mb_meth_cmap_t *m;
 	int i, j;
+	int *first_idx, *poisoned;
 
 	if (l2b == 0) return 0;
 	m = kom_calloc(mb_meth_cmap_t, 1);
@@ -20,9 +25,14 @@ mb_meth_cmap_t *mb_meth_cmap_build(const l2b_t *l2b)
 	if (m->n_internal > 0) {
 		m->out_tid      = kom_calloc(int,     m->n_internal);
 		m->direction    = kom_calloc(char,    m->n_internal);
+		m->canon_tid    = kom_calloc(int,     m->n_internal);
+		m->paired_tid   = kom_calloc(int,     m->n_internal);
 		m->output_names = kom_calloc(char *,  m->n_internal);
 		m->output_lens  = kom_calloc(int64_t, m->n_internal);
 	}
+	/* first_idx[out_tid] = the first internal tid that landed on that out_tid; valid until poisoned[out_tid] is set */
+	first_idx = kom_calloc(int, m->n_internal);
+	poisoned  = kom_calloc(int, m->n_internal);
 	for (i = 0; i < m->n_internal; ++i) {
 		const char *name = l2b->ctg[i].name;
 		const char *stripped = (name[0] == 'f' || name[0] == 'r')? name + 1 : name;
@@ -30,15 +40,41 @@ mb_meth_cmap_t *mb_meth_cmap_build(const l2b_t *l2b)
 		m->direction[i] = (name[0] == 'f' || name[0] == 'r')? name[0] : 0;
 		for (j = 0; j < m->n_output; ++j)
 			if (strcmp(m->output_names[j], stripped) == 0) { existing = j; break; }
-		if (existing >= 0) m->out_tid[i] = existing;
-		else {
+		if (existing >= 0) {
+			int prev = first_idx[existing];
+			m->out_tid[i]    = existing;
+			m->canon_tid[i]  = m->canon_tid[prev]; /* inherit canon from the partner already placed */
+			if (poisoned[existing] || m->paired_tid[prev] >= 0) {
+				/* 3rd-or-later collision: invalidate the whole group's partner links and pin */
+				if (!poisoned[existing] && m->paired_tid[prev] >= 0)
+					m->paired_tid[m->paired_tid[prev]] = -1;
+				m->paired_tid[prev] = -1;
+				m->paired_tid[i]    = -1;
+				poisoned[existing]  = 1;
+			} else if (l2b->ctg[i].len != l2b->ctg[prev].len) {
+				fprintf(stderr, "[WARNING]\033[1;31m --meth f/r partners '%s' and '%s' differ in length (%lld vs %lld); skipping cross-contig pairing for this group.\033[0m\n",
+				        l2b->ctg[prev].name, l2b->ctg[i].name,
+				        (long long)l2b->ctg[prev].len, (long long)l2b->ctg[i].len);
+				m->paired_tid[i]    = -1;
+				m->paired_tid[prev] = -1;
+				poisoned[existing]  = 1;
+			} else {
+				m->paired_tid[prev] = i;
+				m->paired_tid[i]    = prev;
+			}
+		} else {
 			int idx = m->n_output;
 			m->output_names[idx] = kom_strdup(stripped);
-			m->output_lens[idx] = (int64_t)l2b->ctg[i].len;
-			m->out_tid[i] = idx;
+			m->output_lens[idx]  = (int64_t)l2b->ctg[i].len;
+			m->out_tid[i]    = idx;
+			m->canon_tid[i]  = i;
+			m->paired_tid[i] = -1;
+			first_idx[idx]   = i;
 			++m->n_output;
 		}
 	}
+	free(first_idx);
+	free(poisoned);
 	return m;
 }
 
@@ -48,6 +84,8 @@ void mb_meth_cmap_free(mb_meth_cmap_t *m)
 	if (m == 0) return;
 	free(m->out_tid);
 	free(m->direction);
+	free(m->canon_tid);
+	free(m->paired_tid);
 	if (m->output_names) {
 		for (i = 0; i < m->n_output; ++i) free(m->output_names[i]);
 		free(m->output_names);

--- a/meth.c
+++ b/meth.c
@@ -1,0 +1,154 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "kalloc.h"
+#include "kommon.h"
+#include "meth.h"
+
+/* Strip leading 'f'/'r' c2t prefix; collapse paired f<x>/r<x> contigs onto a
+ * single output name; non-prefixed contigs pass through with direction 0. */
+mb_meth_cmap_t *mb_meth_cmap_build(const l2b_t *l2b)
+{
+	mb_meth_cmap_t *m;
+	int i, j;
+
+	if (l2b == 0) return 0;
+	m = kom_calloc(mb_meth_cmap_t, 1);
+	m->n_internal = (int)l2b->n_ctg;
+	if (m->n_internal > 0) {
+		m->out_tid      = kom_calloc(int,     m->n_internal);
+		m->direction    = kom_calloc(char,    m->n_internal);
+		m->output_names = kom_calloc(char *,  m->n_internal);
+		m->output_lens  = kom_calloc(int64_t, m->n_internal);
+	}
+	for (i = 0; i < m->n_internal; ++i) {
+		const char *name = l2b->ctg[i].name;
+		const char *stripped = (name[0] == 'f' || name[0] == 'r')? name + 1 : name;
+		int existing = -1;
+		m->direction[i] = (name[0] == 'f' || name[0] == 'r')? name[0] : 0;
+		for (j = 0; j < m->n_output; ++j)
+			if (strcmp(m->output_names[j], stripped) == 0) { existing = j; break; }
+		if (existing >= 0) m->out_tid[i] = existing;
+		else {
+			int idx = m->n_output;
+			m->output_names[idx] = kom_strdup(stripped);
+			m->output_lens[idx] = (int64_t)l2b->ctg[i].len;
+			m->out_tid[i] = idx;
+			++m->n_output;
+		}
+	}
+	return m;
+}
+
+void mb_meth_cmap_free(mb_meth_cmap_t *m)
+{
+	int i;
+	if (m == 0) return;
+	free(m->out_tid);
+	free(m->direction);
+	if (m->output_names) {
+		for (i = 0; i < m->n_output; ++i) free(m->output_names[i]);
+		free(m->output_names);
+	}
+	free(m->output_lens);
+	free(m);
+}
+
+void mb_meth_ingest(int n_seq, mb_bseq1_t *seq, int frag_mode, int split_files)
+{
+	int i, prev_is_r1 = 0;
+	for (i = 0; i < n_seq; ++i) {
+		mb_bseq1_t *t = &seq[i];
+		const char *prior;
+		size_t prior_len, cap;
+		char *comment, from, from_lo, to;
+		const char *yc;
+		int is_r2, l = (int)t->l_seq, k, off;
+
+		if (!frag_mode)        is_r2 = 0;
+		else if (split_files)  is_r2 = (i & 1);                    /* split-file PE: bseq_read_frag interleaves */
+		else if (prev_is_r1 && i > 0 && mb_qname_same(seq[i-1].name, t->name))
+		                       is_r2 = 1, prev_is_r1 = 0;
+		else                   is_r2 = 0, prev_is_r1 = 1;
+
+		yc = is_r2? "GA" : "CT";
+		from = is_r2? 'G' : 'C';
+		from_lo = is_r2? 'g' : 'c';
+		to = is_r2? 'A' : 'T';
+
+		prior = t->comment;
+		prior_len = prior? strlen(prior) : 0;
+		cap = (size_t)l + 32 + (prior_len? prior_len + 1 : 0);
+		comment = kom_malloc(char, cap);
+		off = snprintf(comment, cap, "YS:Z:");
+		memcpy(comment + off, t->seq, (size_t)l);
+		off += l;
+		off += snprintf(comment + off, cap - off, "\tYC:Z:%s", yc);
+		if (prior_len)
+			snprintf(comment + off, cap - off, "\t%s", prior);
+		free(t->comment);
+		t->comment = comment;
+		for (k = 0; k < l; ++k) {
+			char c = t->seq[k];
+			if (c == from || c == from_lo) t->seq[k] = to;
+		}
+	}
+}
+
+/* Longest M/=/X run on a CIGAR. */
+static int meth_cigar_longest_m(const uint32_t *cigar, int n)
+{
+	int i, longest = 0;
+	for (i = 0; i < n; ++i) {
+		int op = cigar[i] & 0xf;
+		if (op == 0 || op == 7 || op == 8) {
+			int len = (int)(cigar[i] >> 4);
+			if (len > longest) longest = len;
+		}
+	}
+	return longest;
+}
+
+#define MB_METH_MIN_LONGEST_M_PCT 44 /* matches bwameth.py */
+
+static int meth_qc_one(const mb_opt_t *opt, const mb_meth_cmap_t *cmap,
+                       const mb_bseq1_t *t, mb_hit_t *r)
+{
+	int failed = 0;
+	char dir = 0;
+	if (r == 0 || r->p == 0) return 0;
+	if (cmap && r->tid >= 0 && r->tid < cmap->n_internal)
+		dir = cmap->direction[(int)r->tid];
+	if (dir == 0) return 0; /* not on a doubled contig */
+	if (opt->meth_set_as_failed != 0 && opt->meth_set_as_failed == dir)
+		failed = 1;
+	if (!opt->meth_no_chim && r->p->n_cigar > 0 && t->l_seq > 0) {
+		int lm = meth_cigar_longest_m(r->p->cigar, r->p->n_cigar);
+		if (100 * lm < MB_METH_MIN_LONGEST_M_PCT * t->l_seq) {
+			failed = 1;
+			if (r->mapq > 1) r->mapq = 1;
+		}
+	}
+	if (failed) r->qc_fail = 1, r->proper_pair = 0;
+	return failed;
+}
+
+void mb_meth_apply_qc(const mb_opt_t *opt, const mb_meth_cmap_t *cmap,
+                      const mb_bseq1_t *seq, int32_t n_seg,
+                      const int32_t *n_hit, mb_hit_t *const *hit)
+{
+	int any_fail = 0, s, j;
+	if (opt == 0 || hit == 0 || n_hit == 0) return;
+	for (s = 0; s < n_seg; ++s)
+		for (j = 0; j < n_hit[s]; ++j) {
+			mb_hit_t *r = &hit[s][j];
+			if (r->parent == r->id && meth_qc_one(opt, cmap, &seq[s], r))
+				any_fail = 1;
+		}
+	if (!any_fail) return;
+	for (s = 0; s < n_seg; ++s)
+		for (j = 0; j < n_hit[s]; ++j)
+			hit[s][j].qc_fail = 1, hit[s][j].proper_pair = 0;
+}

--- a/meth.h
+++ b/meth.h
@@ -1,0 +1,46 @@
+#ifndef MB_METH_H
+#define MB_METH_H
+
+#include <stdint.h>
+
+#include "l2bit.h"
+#include "minibwa.h"
+#include "bseq.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Tag prefixes (5 chars each, NUL-terminated) used by --meth output. */
+#define MB_METH_YS_PREFIX "YS:Z:"
+#define MB_METH_YC_PREFIX "YC:Z:"
+#define MB_METH_YD_PREFIX "YD:Z:"
+
+/* Chrom-consolidation map: f<name>/r<name> → <name>; built once from l2b. */
+typedef struct mb_meth_cmap_s {
+	int      n_internal;    /* == l2b->n_ctg */
+	int      n_output;      /* consolidated names */
+	int     *out_tid;       /* [n_internal] -> output index */
+	char    *direction;     /* [n_internal] 'f', 'r', or 0 */
+	char   **output_names;  /* [n_output] */
+	int64_t *output_lens;   /* [n_output] */
+} mb_meth_cmap_t;
+
+mb_meth_cmap_t *mb_meth_cmap_build(const l2b_t *l2b);
+void            mb_meth_cmap_free(mb_meth_cmap_t *m);
+
+/* Bisulfite read ingest: project R1 C->T / R2 G->A in place; stash pre-projection
+ * SEQ in YS:Z and conversion direction in YC:Z, appended to t->comment. */
+void mb_meth_ingest(int n_seq, mb_bseq1_t *seq, int frag_mode, int split_files);
+
+/* Chimera QC: flag matching-strand reads (--set-as-failed) and short-longest-M chimeras
+ * (unless --do-not-penalize-chimeras); propagate 0x200 across both segments. */
+void mb_meth_apply_qc(const mb_opt_t *opt, const mb_meth_cmap_t *cmap,
+                      const mb_bseq1_t *seq, int32_t n_seg,
+                      const int32_t *n_hit, mb_hit_t *const *hit);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/meth.h
+++ b/meth.h
@@ -16,18 +16,39 @@ extern "C" {
 #define MB_METH_YC_PREFIX "YC:Z:"
 #define MB_METH_YD_PREFIX "YD:Z:"
 
-/* Chrom-consolidation map: f<name>/r<name> → <name>; built once from l2b. */
+/* Chrom-consolidation map: f<name>/r<name> → <name>; built once from l2b.
+ * f<X> and r<X> partners are guaranteed to have identical length and
+ * orientation, so collapsing them onto a single l2b offset preserves all
+ * fragment-distance arithmetic during pairing. */
 typedef struct mb_meth_cmap_s {
 	int      n_internal;    /* == l2b->n_ctg */
 	int      n_output;      /* consolidated names */
 	int     *out_tid;       /* [n_internal] -> output index */
 	char    *direction;     /* [n_internal] 'f', 'r', or 0 */
+	int     *canon_tid;     /* [n_internal] lowest internal tid sharing out_tid; valid l2b index */
+	int     *paired_tid;    /* [n_internal] f/r partner internal tid sharing out_tid, or -1 if none */
 	char   **output_names;  /* [n_output] */
 	int64_t *output_lens;   /* [n_output] */
 } mb_meth_cmap_t;
 
 mb_meth_cmap_t *mb_meth_cmap_build(const l2b_t *l2b);
 void            mb_meth_cmap_free(mb_meth_cmap_t *m);
+
+/* Resolve tid to its canonical l2b index (collapses f<X>/r<X> onto one).
+ * Returns tid unchanged when cmap is NULL or tid is out of range. */
+static inline int32_t mb_meth_canon_tid(const mb_meth_cmap_t *m, int32_t tid)
+{
+	if (m == 0 || tid < 0 || tid >= m->n_internal) return tid;
+	return m->canon_tid[tid];
+}
+
+/* Resolve tid to its f/r partner internal tid, or -1 if none.
+ * Returns -1 when cmap is NULL or tid is out of range. */
+static inline int32_t mb_meth_paired_tid(const mb_meth_cmap_t *m, int32_t tid)
+{
+	if (m == 0 || tid < 0 || tid >= m->n_internal) return -1;
+	return m->paired_tid[tid];
+}
 
 /* Bisulfite read ingest: project R1 C->T / R2 G->A in place; stash pre-projection
  * SEQ in YS:Z and conversion direction in YC:Z, appended to t->comment. */

--- a/minibwa.1
+++ b/minibwa.1
@@ -242,6 +242,30 @@ A gap of length
 .I k
 costs
 .RI min( O1 + k * E1 , O2 + k * E2 ).
+.TP
+.B -L \fIINT1\fR[,\fIINT2\fR]
+5'- and 3'-end soft-clip penalty [5,5]. After the DP extension, the
+extend-to-end alignment is preferred over a clipped local-best
+alignment iff
+.RI ( mqe + end_bonus + L >= max ),
+where
+.I L
+is the relevant
+.B -L
+value (
+.I INT1
+for 5' /
+.I INT2
+for 3'). Higher
+.I L
+makes the aligner more willing to extend through a noisy read tail
+rather than soft-clip it. Mirrors bwa-mem's
+.BR -L
+flag; bwameth.py invokes
+.B bwa mem -L 10
+and minibwa
+.BR --meth
+matches that default.
 
 .SS Paired-end Options
 .TP 10

--- a/minibwa.1
+++ b/minibwa.1
@@ -300,7 +300,15 @@ Output up to
 secondary alignments [0]. Primary and supplementary alignments are always outputted.
 .TP
 .B -y
-Copy FASTA/Q comments to output
+Append SAM-tag-formatted segments of the FASTA/Q comment to the SAM
+record. The comment is split on tab characters; each segment must
+conform to the SAM aux tag format (e.g.
+.IR BC:Z:CGTAC ),
+and segments that do not match are silently dropped. This safely
+accepts raw Illumina-format fastq, whose
+.IR \(dq1:N:0:CAAGGTAC+NAGATACG\(dq -style
+header tail does not conform to SAM and would otherwise produce a
+malformed aux field; that header tail is discarded.
 .TP
 .B -Y
 In the SAM output, use soft clipping for supplementary alignments

--- a/minibwa.h
+++ b/minibwa.h
@@ -40,7 +40,8 @@ typedef struct {
 	uint64_t flag;
 	// seeding options
 	int32_t min_len; // min seed length
-	int32_t max_sub_occ; // look for shorter seed if smem occ below this value
+	int32_t max_sub_occ; // run Pass-2 sub-SMEM reseeding only when SA-interval size <= this value (0 disables Pass-2)
+	int32_t min_sub_occ; // run Pass-2 sub-SMEM reseeding only when SA-interval size >= this value (default 1 = no lower gate)
 	int32_t max_occ; // max interval occurrence
 	// general algorithm options
 	int32_t bw, bw_long; // bandwidth

--- a/minibwa.h
+++ b/minibwa.h
@@ -22,6 +22,7 @@
 #define MB_F_ADAP             (0x4000LL)    // adaptive mode
 #define MB_F_PRIMARY5         (0x8000LL)
 #define MB_F_NO_PAIRING       (0x10000LL)
+#define MB_F_METH             (0x20000LL)   // bisulfite (methylation) mode; set when --meth is given
 
 #define MB_CIGAR_MATCH      0
 #define MB_CIGAR_INS        1
@@ -82,6 +83,8 @@ typedef struct {
 	int64_t max_mb_size;
 	int64_t max_sw_mat;
 	int64_t cap_kalloc;
+	char    meth_set_as_failed; // --set-as-failed: 'f', 'r', or 0
+	int32_t meth_no_chim;       // --do-not-penalize-chimeras
 } mb_opt_t;
 
 struct mb_idx_s;
@@ -111,7 +114,7 @@ typedef struct {
 	int32_t mlen, blen;
 	int32_t mapq;
 	uint32_t hash;
-	uint32_t rev:1, proper_pair:1, sam_pri:1, flt:1, inv:1, split:2, split_inv:1, rescued:1, frac_high:8, dummy:15;
+	uint32_t rev:1, proper_pair:1, sam_pri:1, flt:1, inv:1, split:2, split_inv:1, rescued:1, frac_high:8, qc_fail:1, dummy:14;
 	mb_extra_t *p;
 } mb_hit_t;
 

--- a/minibwa.h
+++ b/minibwa.h
@@ -62,6 +62,7 @@ typedef struct {
 	int32_t q, q2;    // gap open, long gap open
 	int32_t e, e2;    // gap extension, long gap extension
 	int32_t end_bonus;
+	int32_t pen_clip5, pen_clip3; // 5'/3' soft-clip penalty (bwa-mem `-L`); extend-to-end is preferred to clipping iff mqe+end_bonus+pen_clip >= max
 	int32_t min_dp_max; // min_dp_max*a is the min score
 	int32_t zdrop;
 	int32_t zdrop_inv;

--- a/options.c
+++ b/options.c
@@ -9,6 +9,7 @@ static void mb_opt_reset(mb_opt_t *opt)
 	opt->max_sr_len = 325;
 	// seeding options
 	opt->max_sub_occ = 10;
+	opt->min_sub_occ = 1;
 	opt->max_occ = 250;
 	// chaining options
 	opt->max_chain_skip = 25;

--- a/options.c
+++ b/options.c
@@ -24,6 +24,10 @@ static void mb_opt_reset(mb_opt_t *opt)
 	opt->q = 12, opt->q2 = 23;
 	opt->e = 2,  opt->e2 = 1;
 	opt->b_ambi = 1;
+	/* Default 0 to preserve historical minibwa extend/clip behavior; bwa-mem
+	 * default is 5,5 but enabling that as the minibwa default would shift
+	 * non-meth output unannounced. --meth opts in to bwameth's 10,10. */
+	opt->pen_clip5 = opt->pen_clip3 = 0;
 	// pairing options
 	opt->max_pe_ins = 10000;
 	opt->max_rescue = 10;

--- a/pe.c
+++ b/pe.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <math.h>
 #include "mbpriv.h"
+#include "meth.h"
 #include "kalloc.h"
 #include "ksw2.h"
 
@@ -65,7 +66,7 @@ static int32_t mb_hit_sum_score(void *km, int32_t n_hit, const mb_hit_t *hit)
 	return sc;
 }
 
-void mb_pestat(void *km, const mb_opt_t *opt, int32_t n_frag, const int32_t *seg_off, const int32_t *seg_cnt, const int32_t *n_hit, mb_hit_t *const *hit, mb_pestat_t pes[4])
+void mb_pestat(void *km, const mb_opt_t *opt, const mb_meth_cmap_t *cmap, int32_t n_frag, const int32_t *seg_off, const int32_t *seg_cnt, const int32_t *n_hit, mb_hit_t *const *hit, mb_pestat_t pes[4])
 {
 	const int MIN_DIR_CNT = 20;
 	const double MIN_DIR_RATIO = 0.05, OUTLIER_BOUND = 2.0, MAPPING_BOUND = 3.0, MAX_STDDEV = 4.0;
@@ -82,7 +83,8 @@ void mb_pestat(void *km, const mb_opt_t *opt, int32_t n_frag, const int32_t *seg
 		r[0] = mb_select_unique_se(n_hit[off + 0], hit[off + 0]);
 		r[1] = mb_select_unique_se(n_hit[off + 1], hit[off + 1]);
 		if (r[0] == 0 || r[1] == 0) continue;
-		if (r[0]->tid != r[1]->tid) continue; // not on the same contig
+		// under --meth, f<X>/r<X> partner contigs share a logical coordinate space
+		if (mb_meth_canon_tid(cmap, r[0]->tid) != mb_meth_canon_tid(cmap, r[1]->tid)) continue;
 		dir = mb_insert_dir(r[0], r[1], &dist);
 		if (dist < opt->max_pe_ins) {
 			if (is[dir].n == is[dir].m)
@@ -137,7 +139,7 @@ typedef struct {
 	int32_t i[2];
 } mb_pairaux_t;
 
-static void mb_pair_hits(void *km, const mb_opt_t *opt, const l2b_t *l2b, int32_t n_hit[2], mb_hit_t *hit[2], const mb_pestat_t pes[4], mb_pairaux_t *ret)
+static void mb_pair_hits(void *km, const mb_opt_t *opt, const l2b_t *l2b, const mb_meth_cmap_t *cmap, int32_t n_hit[2], mb_hit_t *hit[2], const mb_pestat_t pes[4], mb_pairaux_t *ret)
 {
 	int32_t r, i, k, n_pa, y[4], n_pp = 0, m_pp = 0;
 	mb128_t *pa, *pp = 0; // pp: proper pairs
@@ -150,7 +152,7 @@ static void mb_pair_hits(void *km, const mb_opt_t *opt, const l2b_t *l2b, int32_
 			mb128_t *p = &pa[n_pa++];
 			mb_hit_t *h = &hit[r][i];
 			h->proper_pair = 0;
-			p->x = l2b->ctg[h->tid].off + (h->rev? h->te : h->ts);
+			p->x = l2b->ctg[mb_meth_canon_tid(cmap, h->tid)].off + (h->rev? h->te : h->ts);
 			p->y = (uint64_t)i << 2 | (uint64_t)h->rev << 1 | r;
 		}
 	}
@@ -160,6 +162,7 @@ static void mb_pair_hits(void *km, const mb_opt_t *opt, const l2b_t *l2b, int32_
 	for (i = 0; i < n_pa; ++i) {
 		mb128_t *pi = &pa[i];
 		mb_hit_t *hi = &hit[pi->y&1][pi->y>>2];
+		int32_t i_canon = mb_meth_canon_tid(cmap, hi->tid); // hoisted: invariant across the inner k-loop
 		for (r = 0; r < 2; ++r) {
 			int which, dir = r << 1 | (pi->y>>1&1);
 			if (pes[dir].failed) continue; // invalid orientation
@@ -171,7 +174,7 @@ static void mb_pair_hits(void *km, const mb_opt_t *opt, const l2b_t *l2b, int32_
 				int64_t dist;
 				double s;
 				if ((pk->y&3) != which) continue;
-				if (hi->tid != hk->tid) break;
+				if (i_canon != mb_meth_canon_tid(cmap, hk->tid)) break;
 				dist = pi->x - pk->x;
 				if (dist > pes[dir].hi) break;
 				if (dist < pes[dir].lo) continue;
@@ -311,12 +314,23 @@ typedef struct {
 	mb_hit_t *a;
 } mb_hit_v;
 
-static const mb_hit_t *mb_matesw_core(void *km, const mb_opt_t *opt, const l2b_t *l2b, const mb_pestat_t pes[4], const mb_hit_t *h0, int32_t r0,
+static const mb_hit_t *mb_matesw_core(void *km, const mb_opt_t *opt, const l2b_t *l2b, const mb_meth_cmap_t *cmap, const mb_pestat_t pes[4], const mb_hit_t *h0, int32_t r0,
 	int32_t len, uint8_t *seq[2], mb_hit_v *h1, int32_t min_sc, ksw_extz_t *ez)
 {
 	int32_t dir, skip[4];
 	int64_t pos5;
 	const mb_hit_t *ret = 0;
+	/* cmap is threaded through but not used for target-contig switching here. An
+	 * earlier draft redirected the rescue window to the f/r partner contig under
+	 * --meth (rescue R2-on-f<X> against r<X> on the assumption of a directional
+	 * library). That broke non-directional libraries (twist-emseq real, encode WGBS,
+	 * holodeck non-directional sims) where R2's correct rescue target is the SAME
+	 * doubled contig as h0. The cross-contig pairing logic in mb_pair_hits is enough
+	 * to recover the directional case via primary placements; mate rescue stays
+	 * single-contig as in pre-cross-contig minibwa. A try-both rescue (same and
+	 * partner, take the better score) is reasonable future work. */
+	int32_t target_tid = h0->tid;
+	(void)cmap; /* silence unused warning if helpers above optimise out */
 	// find permitted orientation
 	for (dir = 0; dir < 4; ++dir) skip[dir] = !!pes[dir].failed;
 	if (skip[0] + skip[1] + skip[2] + skip[3] == 4) return 0; // no need to perform SW
@@ -332,7 +346,7 @@ static const mb_hit_t *mb_matesw_core(void *km, const mb_opt_t *opt, const l2b_t
 		ts = (is_larger? pos5 + pes[dir].lo : pos5 - pes[dir].hi) - (!is_rev? 0 : len);
 		te = (is_larger? pos5 + pes[dir].hi : pos5 - pes[dir].lo) + (!is_rev? len : 0);
 		if (ts < 0) ts = 0;
-		if (te > l2b->ctg[h0->tid].len) te = l2b->ctg[h0->tid].len;
+		if (te > l2b->ctg[target_tid].len) te = l2b->ctg[target_tid].len;
 		if (te - ts > len) {
 			int64_t ts2 = ts, te2 = te;
 			int32_t max_ug, max_i, n_good, n_kmer;
@@ -340,7 +354,7 @@ static const mb_hit_t *mb_matesw_core(void *km, const mb_opt_t *opt, const l2b_t
 			mb_hit_t ht;
 			ht.p = 0;
 			ref = Kmalloc(km, uint8_t, te - ts);
-			l2b_getseq(l2b, h0->tid, ts, te, ref);
+			l2b_getseq(l2b, target_tid, ts, te, ref);
 			max_ug = mb_ungap(km, len, seq[is_rev], te - ts, ref, 7, &max_i, &n_good, &n_kmer);
 			if (max_ug >= 10 && max_ug >= len>>1 && n_good == 1) {
 				ts2 = ts + max_i - len / 2;
@@ -357,7 +371,7 @@ static const mb_hit_t *mb_matesw_core(void *km, const mb_opt_t *opt, const l2b_t
 			if ((opt->flag & MB_F_METH) || max_ug >= 10 || max_ug >= n_kmer * 0.33)
 				mb_matesw_align(km, opt, len, seq[is_rev], te2 - ts2, &ref[ts2 - ts], &ht, min_sc, ez);
 			if (ht.p) { // a good hit found
-				ht.tid = h0->tid;
+				ht.tid = target_tid;
 				ht.ts += ts2, ht.te += ts2;
 				ht.rev = is_rev;
 				if (is_rev) {
@@ -376,7 +390,7 @@ static const mb_hit_t *mb_matesw_core(void *km, const mb_opt_t *opt, const l2b_t
 	return ret;
 }
 
-static int32_t mb_matesw(void *km, const mb_opt_t *opt, const l2b_t *l2b, int32_t n_hit[2], mb_hit_t *hit[2], const mb_pestat_t pes[4], const mb_pairaux_t *paux0, int32_t qlen[2], char *const qseq[2])
+static int32_t mb_matesw(void *km, const mb_opt_t *opt, const l2b_t *l2b, const mb_meth_cmap_t *cmap, int32_t n_hit[2], mb_hit_t *hit[2], const mb_pestat_t pes[4], const mb_pairaux_t *paux0, int32_t qlen[2], char *const qseq[2])
 {
 	int32_t i, r, n_add, n_res, max[2], max2[2], skip[2], min_sc[2];
 	mb_hit_v ha[2];
@@ -437,7 +451,7 @@ static int32_t mb_matesw(void *km, const mb_opt_t *opt, const l2b_t *l2b, int32_
 		int32_t sc, r = a[i].y&1, j = a[i].y>>1;
 		const mb_hit_t *h0 = &ha[r].a[j], *h1;
 		if (skip[r]) continue;
-		h1 = mb_matesw_core(km, opt, l2b, pes, h0, r, qlen[!r], qs[!r], &ha[!r], min_sc[!r], &ez);
+		h1 = mb_matesw_core(km, opt, l2b, cmap, pes, h0, r, qlen[!r], qs[!r], &ha[!r], min_sc[!r], &ez);
 		if (h1) { // rescue successful
 			sc = mb_pair_score(h0, h1, pes, opt->a);
 			if (sc > max[r]) max2[r] = max[r], max[r] = sc;
@@ -455,17 +469,17 @@ static int32_t mb_matesw(void *km, const mb_opt_t *opt, const l2b_t *l2b, int32_
 	return n_add;
 }
 
-void mb_pair(void *km, const mb_opt_t *opt, const l2b_t *l2b, int32_t n_hit[2], mb_hit_t *hit[2], const mb_pestat_t pes[4], int32_t qlen[2], char *const qseq[2])
+void mb_pair(void *km, const mb_opt_t *opt, const l2b_t *l2b, const mb_meth_cmap_t *cmap, int32_t n_hit[2], mb_hit_t *hit[2], const mb_pestat_t pes[4], int32_t qlen[2], char *const qseq[2])
 {
 	int32_t r, i, score_se, do_matesw;
 	mb_pairaux_t paux;
 	mb_hit_t *h[2];
 
-	mb_pair_hits(km, opt, l2b, n_hit, hit, pes, &paux);
+	mb_pair_hits(km, opt, l2b, cmap, n_hit, hit, pes, &paux);
 	do_matesw = paux.n_pp > 0 && paux.score == paux.sub_sc? 0 : 1; // skip mate rescue if we see two equally best pairs
 	if (do_matesw && opt->max_rescue > 0) {
 		int32_t sub_diff = opt->a + opt->b > opt->q + opt->e? opt->a + opt->b : opt->q + opt->e;
-		if (mb_matesw(km, opt, l2b, n_hit, hit, pes, &paux, qlen, qseq) > 0) {
+		if (mb_matesw(km, opt, l2b, cmap, n_hit, hit, pes, &paux, qlen, qseq) > 0) {
 			for (r = 0; r < 2; ++r) {
 				for (i = 0; i < n_hit[r]; ++i) {
 					mb_hit_t *h = &hit[r][i];
@@ -476,7 +490,7 @@ void mb_pair(void *km, const mb_opt_t *opt, const l2b_t *l2b, int32_t n_hit[2], 
 				mb_set_parent(km, opt->mask_level, opt->mask_len, n_hit[r], hit[r], sub_diff, 0);
 				mb_set_mapq(km, qlen[r], n_hit[r], hit[r], opt->min_chain_score, opt->a, mb_is_sr_mode(opt, qlen[r]), opt->max_sr_len);
 			}
-			mb_pair_hits(km, opt, l2b, n_hit, hit, pes, &paux); // pair again if new hits rescued
+			mb_pair_hits(km, opt, l2b, cmap, n_hit, hit, pes, &paux); // pair again if new hits rescued
 		}
 	}
 	if (paux.n_pp == 0) goto end_pairing;

--- a/pe.c
+++ b/pe.c
@@ -348,7 +348,13 @@ static const mb_hit_t *mb_matesw_core(void *km, const mb_opt_t *opt, const l2b_t
 				if (ts2 < ts) ts2 = ts;
 				if (te2 > te) te2 = te;
 			}
-			if (max_ug >= 10 || max_ug >= n_kmer * 0.33)
+			/* Under --meth the bisulfite-projected R2 has a 2-letter alphabet
+			 * (A/T after G->A) and the k=7 ungapped prefilter mis-rejects
+			 * ~90% of rescuable candidates because contiguous 7-mer matches
+			 * are rare in low-complexity space. Bypass the prefilter under
+			 * --meth and let mb_matesw_align decide; bwa-mem has no
+			 * equivalent prefilter. */
+			if ((opt->flag & MB_F_METH) || max_ug >= 10 || max_ug >= n_kmer * 0.33)
 				mb_matesw_align(km, opt, len, seq[is_rev], te2 - ts2, &ref[ts2 - ts], &ht, min_sc, ez);
 			if (ht.p) { // a good hit found
 				ht.tid = h0->tid;

--- a/seed.c
+++ b/seed.c
@@ -21,7 +21,7 @@ KRADIX_SORT_INIT(mb_anchor, mb_anchor_t, key_anchor, 8)
  * Seeding *
  ***********/
 
-void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq, int32_t min_len, int32_t max_sub_occ, mb_sai_v *v)
+void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq, int32_t min_len, int32_t max_sub_occ, int32_t min_sub_occ, mb_sai_v *v)
 {
 	int64_t x = 0, i, n_a0;
 	mb_sai_t p;
@@ -39,7 +39,7 @@ void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq
 	for (i = 0; i < n_a0; ++i) { // pass 2: sub-SMEMs
 		int32_t sub_min_len;
 		uint32_t st = v->a[i].info>>32, en = (uint32_t)v->a[i].info;
-		if (en - st < min_len * 2 || v->a[i].size > max_sub_occ)
+		if (en - st < min_len * 2 || v->a[i].size > max_sub_occ || v->a[i].size < min_sub_occ)
 			continue;
 		x = st;
 		sub_min_len = (en - st) / 2 > min_len? (en - st) / 2 : min_len;
@@ -53,7 +53,7 @@ void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq
 	}
 }
 
-void mb_seed_intv_batch(void *km, const mb_bwt_t *bwt, int32_t n_seq, const int32_t *len, uint8_t *const* seq, int32_t min_len, int32_t max_sub_occ, mb_sai_v *v)
+void mb_seed_intv_batch(void *km, const mb_bwt_t *bwt, int32_t n_seq, const int32_t *len, uint8_t *const* seq, int32_t min_len, int32_t max_sub_occ, int32_t min_sub_occ, mb_sai_v *v)
 { // identical to mb_seed_intv() though the order of intervals is often different
 	const int max_batch_size = 50;
 	mb_smem_entry_t *s;
@@ -82,7 +82,7 @@ void mb_seed_intv_batch(void *km, const mb_bwt_t *bwt, int32_t n_seq, const int3
 		for (j = 0; j < nv[i]; ++j) {
 			mb_smem_entry_t *t;
 			uint32_t st = v[i].a[j].info>>32, en = (uint32_t)v[i].a[j].info;
-			if (en - st < min_len * 2 || v[i].a[j].size > max_sub_occ)
+			if (en - st < min_len * 2 || v[i].a[j].size > max_sub_occ || v[i].a[j].size < min_sub_occ)
 				continue;
 			t = &s[n_s++];
 			t->min_len = (en - st) / 2 > min_len? (en - st) / 2 : min_len;


### PR DESCRIPTION
## Summary

Adds bisulfite alignment to minibwa via `--meth` (output-compatible with bwameth.py), plus cross-contig proper-pair recognition under the c2t/g2a doubled reference — fixing the bwa-meth-as-wrapper limitation @lh3 identified in [#9 (comment)](https://github.com/lh3/minibwa/pull/9#issuecomment-4399294573).

Two iterations:

- **Iteration 1** (`f8803da` and earlier on branch): `index --meth` builds the bwameth-compatible doubled c2t companion FASTA; `map --meth` does ingest projection (R1 C→T / R2 G→A) with YS:Z / YC:Z stash, doubled-contig SAM consolidation, chimera QC, mate-rescue ungap-prefilter bypass, scoring defaults.
- **Iteration 2** (`8d5b61d`, `465db5f` on top): cross-contig proper-pair recognition under `--meth` — primary placements of R1 and R2 on f<X>/r<X> partner contigs are now collapsed onto a single logical coordinate space for fragment-distance, orientation, and insert-size estimation. Plus `--max-sub-occ` / `--min-sub-occ` CLI ablation flags for the Pass-2 sub-SMEM reseeding experiments raised in [#10](https://github.com/lh3/minibwa/issues/10).

## Iteration 2: cross-contig PE pairing

In a directional bisulfite library against a c2t/g2a-doubled reference, R1 maps to an `f<X>` (C-to-T-converted) contig and R2 maps to its `r<X>` (G-to-A-converted) partner. To bwa-mem these are different contigs → no proper-pair recognition. Iteration 1 inherited this limitation.

This iteration teaches minibwa to treat `f<X>`/`r<X>` as the same logical coordinate space when `--meth` is set:

- `mb_meth_cmap_t` gains `canon_tid[]` (lowest internal tid sharing `out_tid`; a valid `l2b->ctg[]` index) and `paired_tid[]` (the f/r partner internal tid, or −1). Computed in a single pass; ≥3 internal tids on one out_tid pins the whole group's `paired_tid` to −1 (ambiguous). Length-mismatched f/r partners warn and stay unpaired (no abort).
- `mb_pair_hits` and `mb_pestat` collapse `f<X>`/`r<X>` hits via `canon_tid` so fragment-distance / orientation logic and auto insert-size estimation see one logical contig.
- Static inline helpers `mb_meth_canon_tid()` / `mb_meth_paired_tid()` exposed in `meth.h`.
- `mb_pair` / `mb_pair_hits` / `mb_matesw` / `mb_matesw_core` / `mb_pestat` take a `cmap` parameter; the streaming pipeline threads `s->p->cmap`, the batch API builds it on demand.

Mate rescue is intentionally **not** redirected to the f/r partner contig. An earlier draft did that, but it caused 2–5 pp proper-pair regressions on real non-directional bisulfite fixtures (twist-emseq, encode WGBS, holodeck non-directional sim) where the same-contig rescue path is correct. Cross-contig pairing alone recovers the directional case via primary placements without needing rescue. A try-both rescue (run against same-contig and partner, take the better score) is reasonable future work.

## Validation

m7a.8xlarge (32 vCPU AMD Zen 4, AVX-512), full GRCh38/hs38DH (`hs38DH.fa.bwameth.c2t`).

### Iteration 1 vs Iteration 2 — proper-pair primary rate

| Fixture | Library | Pairs | iter-1 | iter-2 | Δ |
|---|---|---:|---:|---:|---:|
| holodeck-twistlike | non-directional | ~2 M | 99.61% | 99.61% | 0.00 |
| twist-real (Twist EM-seq) | non-directional | 1 M | 93.60% | 93.60% | 0.00 |
| encode-gm12878-wgbs (WGBS) | non-directional | 100 k | 95.32% | 95.32% | 0.00 |
| chr22 holodeck em-seq | **directional** | 1 M | **62.09%** | **70.39%** | **+8.30 pp** |

Of the 254 k newly proper-paired pairs on the directional chr22 fixture, **all are cross-contig f<X>+r<X> pairs** (R1 on one prefix, R2 on the other) — exactly the population the change targets.

### Iteration 1's bwameth.py concordance results, preserved

Iteration 2 does not change per-read alignments on the iteration-1 validation fixtures (same SAM bodies, byte-identical primary mapped counts on holodeck-twistlike / twist-real / encode-gm12878-wgbs). Iteration 1's bwameth.py-vs-minibwa concordance results carry over unchanged:

- Per-CpG methylation calls vs ground truth (holodeck): minibwa Pearson 0.78970, bwameth 0.78958
- MAPQ ≥ 60 placement concordance vs bwameth: holodeck 99.95%, twist-real 97.89%, encode-gm12878-wgbs 99.43%

### Non-meth alignment

Byte-identical to `f8803da` baseline (md5 verified on a WGS-1M PE smoke).

## Iteration 2 also adds: `--max-sub-occ` / `--min-sub-occ` CLI ablation flags

Two flags expose the existing `max_sub_occ` knob plus a new lower bound:

- `--max-sub-occ N` (default 10): run Pass-2 only when SMEM SA-interval size ≤ N. `N=0` disables Pass-2 entirely.
- `--min-sub-occ N` (default 1): run Pass-2 only when SMEM SA-interval size ≥ N. Default preserves current behavior bit-for-bit.

These are measurement knobs for the segdup/paralog ablation experiments tracked in [#10](https://github.com/lh3/minibwa/issues/10).

## Test coverage

`api-test/ex-meth-cmap.c` (new) — 25 assertions covering no-doubled, paired f/r, three- and four-way out_tid collisions, length mismatch, and mixed doubled+plain references. `make -C api-test test`.

## Iteration 1 details (unchanged from original PR)

Three commits comprising iteration 1:

1. **`feat(align): 5'/3' soft-clip penalty (-L)`** — generic ksw2 feature mirroring bwa-mem's `-L`. Default `0,0` preserves historical minibwa behavior; `-L INT[,INT]` opts in.
2. **`feat(meth): map`** — `map --meth`: ingest projection (R1 C→T / R2 G→A) with YS:Z / YC:Z stash, doubled-c2t header consolidation, SAM SEQ restoration, PE chimera-QC propagation (FLAG 0x200), TLEN gating, mate-rescue ungap-prefilter bypass, scoring defaults.
3. **`feat(meth): index`** — `index --meth`: build the doubled c2t companion FASTA (`<ref>.bwameth.c2t`); `map --meth` auto-resolves to it.

CLI: `--meth`, `--set-as-failed=f|r`, `--do-not-penalize-chimeras`, plus `-L INT[,INT]`.

### Iteration 1 validation

Compared against `bwameth.py` + bwa-mem2 on three fixtures, full **GRCh38/hs38DH** reference (run on AWS EC2 m7a.8xlarge, 32 vCPU AMD Zen 4, AVX-512):

#### Per-CpG methylation calls vs ground truth (holodeck simulator)

| Aligner | Pearson r vs truth | n CpGs (≥4× both) |
|---|---|---|
| **minibwa --meth** | **0.78970** | 290,909 |
| bwameth.py | 0.78958 | 293,054 |

minibwa and bwameth agree to within Δr = 1.2×10⁻⁴, ΔMAD = 2×10⁻⁵ — statistically indistinguishable. Pearson ≈ 0.79 reflects the chr22-restricted coverage floor, not aligner quality: the truth bedGraph covers chr22 only, but the simulator targets genome-wide Twist panel regions, so chr22-restricted mean coverage averages ~3.9×.

#### Placement concordance — both aligners ≥ MAPQ 60

| Fixture | n at filter | Concordance @ both ≥ MAPQ 60 |
|---|---|---|
| holodeck-twistlike (simulated) | 2,651,705 | **99.95%** |
| twist-real (Twist EM-seq, 1M pairs) | 1,606,602 | **97.89%** |
| encode-gm12878-wgbs (WGBS, 100k pairs) | 152,517 | **99.43%** |

QC-pass mapped-count parity: minibwa is between −1.10% (twist-real R2) and +0.65% (twist-real R1) of bwameth's QC-pass count.

#### Per-CpG methylation concordance (MethylDackel) — aligner vs aligner

| Fixture | n at ≥4× both | Pearson r |
|---|---|---|
| twist-real | 475,457 | 0.95850 |
| encode-gm12878-wgbs | 98 | 0.99465 (low N — 100k pairs against full hs38DH gives ~0.01× coverage) |

### Iteration 1 datasets

| Fixture | Source | Public access |
|---|---|---|
| `holodeck-twistlike` | Simulated by [holodeck](https://github.com/fg-labs/holodeck), a Twist-panel-targeted bisulfite read simulator | Reproducible from seed |
| `twist-real` (first 1M pairs) | Twist Methylation Detection Panel demo data | Available on request from Twist Bioscience |
| `encode-gm12878-wgbs` (first 100k pairs) | ENCODE GM12878 WGBS, [ENCSR890UQO](https://www.encodeproject.org/experiments/ENCSR890UQO/) → [SRR4235788](https://www.ncbi.nlm.nih.gov/sra/SRR4235788) | Public; streamable from ENA: `ftp.sra.ebi.ac.uk/vol1/fastq/SRR423/008/SRR4235788/SRR4235788_{1,2}.fastq.gz` |

## Known limitations / follow-up

- **`cmap` is rebuilt per `mb_map_batch` call** (the public batch-API path). Streaming CLI unaffected. Moving `cmap` onto `mb_idx_t` is the natural fix; deferred to its own PR.
- **Mate-rescue cross-contig switching**: `paired_tid` helper exists in code but `mb_matesw_core` does not consult it (per the regression results above). A try-both-targets rescue (same-contig and partner, take the better score) is the right design and tracked separately.
- **SMEM-flood resilience under `--meth`** (carried from iteration 1): ~5% of bwameth-MAPQ60 reads on real bisulfite data go unmapped in minibwa `--meth`, primarily in CpG islands where C→T projection collapses the effective alphabet and Pass-1 SMEMs commit to the wrong genomic position. Cross-contig pairing recovers some of the affected pairs by enabling proper-pair recognition where iter-1 silently dropped them, but the underlying SMEM-flood issue is unchanged. Tracked separately.
