### PR TITLE
fix(map): drop is_pe param from mb_map_batch definition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: make -j$(nproc)
+      - run: make -j$(nproc) -C api-test

--- a/map-algo.c
+++ b/map-algo.c
@@ -652,7 +652,7 @@ mb_hit_t *mb_map(const mb_opt_t *opt, const mb_idx_t *idx, int32_t qlen, const c
 	return ret;
 }
 
-mb_hit_t **mb_map_batch(const mb_opt_t *opt, const mb_idx_t *idx, int32_t n_seq, const int32_t *qlen, const char **seq, int32_t is_pe, int32_t *n_hit, mb_tbuf_t *b0, const char **qname)
+mb_hit_t **mb_map_batch(const mb_opt_t *opt, const mb_idx_t *idx, int32_t n_seq, const int32_t *qlen, const char **seq, int32_t *n_hit, mb_tbuf_t *b0, const char **qname)
 {
 	mb_tbuf_t *b;
 	mb_hit_t **hit;


### PR DESCRIPTION
## Summary

r308 (`is_pe is redundant in mb_map_batch`, bd09926) removed `is_pe` from the `mb_map_batch` declaration in `minibwa.h` and from the call site in `api-test/ex-batch.c`, but left it on the function definition in `map-algo.c`. The shadowing local

```c
int32_t i, j, k, sb_st, sb_len, sb_max, is_pe = !!(opt->flag & MB_F_PE);
```

then collides with the parameter, so master fails to build:

```
map-algo.c:655: error: conflicting types for 'mb_map_batch'
map-algo.c:662: error: redefinition of 'is_pe'
```

This PR is two commits:

1. **`ci: add minimal build workflow for push and pull_request`** — Adds `.github/workflows/build.yml` that runs `make` and `make -C api-test` on Ubuntu for push to master and any PR. No test suite, no matrix, no caching — just enough to make sure the tree compiles. This commit alone fails CI on top of master, demonstrating that the workflow surfaces the regression.
2. **`fix(map): drop is_pe param from mb_map_batch definition`** — One-line fix, dropping the leftover parameter so the definition matches the header.

## Test plan

- [x] `make` passes on the fix commit (verified locally on macOS / clang)
- [x] `make -C api-test` passes on the fix commit
- [x] `make` fails at the CI-only commit (verified locally; produces the conflicting-types / redefinition errors above)
- [ ] CI run on this PR is green at HEAD and red at the CI-only commit (will show on the Actions tab once the workflow lands)