### PR TITLE
feat(map): expose --max-sub-occ and --min-sub-occ CLI ablation flags

### DIFF
--- a/map-algo.c
+++ b/map-algo.c
@@ -655,7 +655,7 @@ mb_hit_t *mb_map(const mb_opt_t *opt, const mb_idx_t *idx, int32_t qlen, const c
 	seq = Kmalloc(b->km, uint8_t, qlen);
 	for (i = 0; i < qlen; ++i)
 		seq[i] = kom_nt4_table[(uint8_t)seq0[i]];
-	mb_seed_intv(b->km, idx->bwt, qlen, seq, opt->min_len, opt->max_sub_occ, &u);
+	mb_seed_intv(b->km, idx->bwt, qlen, seq, opt->min_len, opt->max_sub_occ, opt->min_sub_occ, &u);
 	kfree(b->km, seq);
 	ret = mb_map_sai(&opt_adap, idx, qlen, seq0, mt, &u, n_hit_, b, qname);
 	if (b0 == 0) mb_tbuf_destroy(b);
@@ -697,7 +697,7 @@ mb_hit_t **mb_map_batch(const mb_opt_t *opt, const mb_idx_t *idx, int32_t n_seq,
 
 			// batch SMEM for sub-batch
 			memset(sai, 0, sb_n * sizeof(mb_sai_v));
-			mb_seed_intv_batch(km, idx->bwt, sb_n, &qlen[sb_st], seq4, opt->min_len, opt->max_sub_occ, sai);
+			mb_seed_intv_batch(km, idx->bwt, sb_n, &qlen[sb_st], seq4, opt->min_len, opt->max_sub_occ, opt->min_sub_occ, sai);
 			for (k = 0; k < sb_n; ++k) kfree(km, seq4[k]);
 
 			// map each sequence in sub-batch

--- a/map-main.c
+++ b/map-main.c
@@ -69,7 +69,7 @@ static void worker_for_se_batch(void *data, long i, int tid)
 		}
 	}
 	assert(p == n);
-	mb_seed_intv_batch(km, idx->bwt, n, len, seq, opt->min_len, opt->max_sub_occ, sai);
+	mb_seed_intv_batch(km, idx->bwt, n, len, seq, opt->min_len, opt->max_sub_occ, opt->min_sub_occ, sai);
 	kfree(km, seq);
 	kfree(km, len);
 	kfree(km, buf);
@@ -301,6 +301,8 @@ static ko_longopt_t long_options[] = {
 	{ "chain-only",   ko_no_argument,       309 },
 	{ "meth",         ko_no_argument,       310 },
 	{ "hic",          ko_no_argument,       311 },
+	{ "max-sub-occ",  ko_required_argument, 312 }, // ablation: 0 disables Pass-2 sub-SMEM reseeding
+	{ "min-sub-occ",  ko_required_argument, 313 }, // ablation: skip Pass-2 for SMEMs with SA-interval size < N (default 1)
 	{ "dbg-aln-seq",  ko_no_argument,       601 },
 	{ "dbg-anchor",   ko_no_argument,       602 },
 	{ "dbg-seed",     ko_no_argument,       603 },
@@ -334,6 +336,8 @@ static int usage(FILE *fp, const mb_opt_t *opt)
 	fprintf(fp, "    -p FLOAT         min secondary-to-primary score ratio [%g]\n", opt->pri_ratio);
 	fprintf(fp, "    -N INT           retain at most INT secondary alignments [%d]\n", opt->best_n);
 	fprintf(fp, "    --chain-only     perform chaining only without base alignment\n");
+	fprintf(fp, "    --max-sub-occ=INT  reseed Pass-2 sub-SMEMs only when SA-interval size <= INT (0 disables Pass-2) [%d]\n", opt->max_sub_occ);
+	fprintf(fp, "    --min-sub-occ=INT  skip Pass-2 reseeding when SA-interval size < INT [%d]\n", opt->min_sub_occ);
 	fprintf(fp, "    -x STR           preset (sr, lr or adap for mixed short/long reads) [adap]\n");
 	fprintf(fp, "  Alignment:\n");
 	fprintf(fp, "    -A INT           matching score [%d]\n", opt->a);
@@ -441,6 +445,10 @@ int main_map(int argc, char *argv[])
 			mo.flag |= MB_F_METH;
 		} else if (c == 311) { // --hic
 			mo.flag |= MB_F_PRIMARY5 | MB_F_NO_PAIRING;
+		} else if (c == 312) { // --max-sub-occ
+			mo.max_sub_occ = atoi(o.arg);
+		} else if (c == 313) { // --min-sub-occ
+			mo.min_sub_occ = atoi(o.arg);
 		} else if (c == 601) { // --dbg-aln-seq
 			kom_dbg_flag |= MB_DBG_ALN_SEQ;
 		} else if (c == 602) { // --dbg-anchor
@@ -479,6 +487,10 @@ int main_map(int argc, char *argv[])
 		} else if (c == 902) { // --help
 			return usage(stdout, &mo);
 		}
+	}
+	if (mo.max_sub_occ > 0 && mo.min_sub_occ > mo.max_sub_occ) {
+		fprintf(stderr, "[ERROR] --min-sub-occ (%d) must not exceed --max-sub-occ (%d)\n", mo.min_sub_occ, mo.max_sub_occ);
+		return 1;
 	}
 	if (argc - o.ind < 2)
 		return usage(stderr, &mo);

--- a/mbpriv.h
+++ b/mbpriv.h
@@ -53,8 +53,8 @@ void mb_opt_adap(const mb_opt_t *opt0, int32_t len, mb_opt_t *opt);
 void mb_bwtgen(const char *fn_pac, const char *fn_bwt, int block_size);
 
 // defined in seed.c
-void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq, int32_t min_len, int32_t max_sub_occ, mb_sai_v *v);
-void mb_seed_intv_batch(void *km, const mb_bwt_t *bwt, int32_t n_seq, const int32_t *len, uint8_t *const* seq, int32_t min_len, int32_t max_sub_occ, mb_sai_v *v);
+void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq, int32_t min_len, int32_t max_sub_occ, int32_t min_sub_occ, mb_sai_v *v);
+void mb_seed_intv_batch(void *km, const mb_bwt_t *bwt, int32_t n_seq, const int32_t *len, uint8_t *const* seq, int32_t min_len, int32_t max_sub_occ, int32_t min_sub_occ, mb_sai_v *v);
 double mb_anchor(void *km, const mb_idx_t *idx, mb_sai_v *u, int32_t min_len, int32_t qlen, const uint8_t *qseq, l2b_meth_t mt, int32_t max_occ, mb_anchor_v *v);
 void mb_anchor_sort(const l2b_t *l2b, int64_t n_a, mb_anchor_t *a);
 

--- a/minibwa.h
+++ b/minibwa.h
@@ -40,7 +40,8 @@ typedef struct {
 	uint64_t flag;
 	// seeding options
 	int32_t min_len; // min seed length
-	int32_t max_sub_occ; // look for shorter seed if smem occ below this value
+	int32_t max_sub_occ; // run Pass-2 sub-SMEM reseeding only when SA-interval size <= this value (0 disables Pass-2)
+	int32_t min_sub_occ; // run Pass-2 sub-SMEM reseeding only when SA-interval size >= this value (default 1 = no lower gate)
 	int32_t max_occ; // max interval occurrence
 	// general algorithm options
 	int32_t bw, bw_long; // bandwidth

--- a/options.c
+++ b/options.c
@@ -9,6 +9,7 @@ static void mb_opt_reset(mb_opt_t *opt)
 	opt->max_sr_len = 325;
 	// seeding options
 	opt->max_sub_occ = 10;
+	opt->min_sub_occ = 1;
 	opt->max_occ = 250;
 	// chaining options
 	opt->max_chain_skip = 25;

--- a/seed.c
+++ b/seed.c
@@ -21,7 +21,7 @@ KRADIX_SORT_INIT(mb_anchor, mb_anchor_t, key_anchor, 8)
  * Seeding *
  ***********/
 
-void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq, int32_t min_len, int32_t max_sub_occ, mb_sai_v *v)
+void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq, int32_t min_len, int32_t max_sub_occ, int32_t min_sub_occ, mb_sai_v *v)
 {
 	int64_t x = 0, i, n_a0;
 	mb_sai_t p;
@@ -39,7 +39,7 @@ void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq
 	for (i = 0; i < n_a0; ++i) { // pass 2: sub-SMEMs
 		int32_t sub_min_len;
 		uint32_t st = v->a[i].info>>32, en = (uint32_t)v->a[i].info;
-		if (en - st < min_len * 2 || v->a[i].size > max_sub_occ)
+		if (en - st < min_len * 2 || v->a[i].size > max_sub_occ || v->a[i].size < min_sub_occ)
 			continue;
 		x = st;
 		sub_min_len = (en - st) / 2 > min_len? (en - st) / 2 : min_len;
@@ -53,7 +53,7 @@ void mb_seed_intv(void *km, const mb_bwt_t *bwt, int32_t len, const uint8_t *seq
 	}
 }
 
-void mb_seed_intv_batch(void *km, const mb_bwt_t *bwt, int32_t n_seq, const int32_t *len, uint8_t *const* seq, int32_t min_len, int32_t max_sub_occ, mb_sai_v *v)
+void mb_seed_intv_batch(void *km, const mb_bwt_t *bwt, int32_t n_seq, const int32_t *len, uint8_t *const* seq, int32_t min_len, int32_t max_sub_occ, int32_t min_sub_occ, mb_sai_v *v)
 { // identical to mb_seed_intv() though the order of intervals is often different
 	const int max_batch_size = 50;
 	mb_smem_entry_t *s;
@@ -82,7 +82,7 @@ void mb_seed_intv_batch(void *km, const mb_bwt_t *bwt, int32_t n_seq, const int3
 		for (j = 0; j < nv[i]; ++j) {
 			mb_smem_entry_t *t;
 			uint32_t st = v[i].a[j].info>>32, en = (uint32_t)v[i].a[j].info;
-			if (en - st < min_len * 2 || v[i].a[j].size > max_sub_occ)
+			if (en - st < min_len * 2 || v[i].a[j].size > max_sub_occ || v[i].a[j].size < min_sub_occ)
 				continue;
 			t = &s[n_s++];
 			t->min_len = (en - st) / 2 > min_len? (en - st) / 2 : min_len;


### PR DESCRIPTION
## Summary

Exposes the existing Pass-2 sub-SMEM reseeding threshold on the CLI, and adds a symmetric lower-bound knob for ablation studies. **No change to default behavior.**

### What master already does

`mb_seed_intv` / `mb_seed_intv_batch` run a two-pass seeding loop. Pass-1 collects standard SMEMs; Pass-2 reseeds *inside* each Pass-1 SMEM to find shorter sub-SMEMs that could anchor paralog hits. Pass-2 is gated on the Pass-1 SMEM's SA-interval size: a hard-coded `opt->max_sub_occ = 10` in `options.c` skips Pass-2 for any SMEM with size > 10. There was no lower bound, but Pass-1 only appends SMEMs with `size > 0`, so the effective floor was 1.

### What this PR changes

| Flag | Default | Effect |
| --- | --- | --- |
| `--max-sub-occ N` | `10` | Existing internal threshold, now CLI-exposed. Skip Pass-2 for SMEMs with size > N. `N=0` disables Pass-2 entirely (ablation knob). |
| `--min-sub-occ N` | `1`  | New symmetric lower bound. Skip Pass-2 for SMEMs with size < N. Default of 1 is a no-op since SMEM sizes are always ≥ 1; intended as an ablation for the "skip Pass-2 on uniquely-anchored SMEMs" hypothesis. |

Defaults reproduce master bit-for-bit. Both flags gate on the same SMEM SA-interval size field; symmetric naming reflects that.

Plumbed through the `mb_seed_intv` / `mb_seed_intv_batch` signatures (`mbpriv.h`, `seed.c`) and the three callers in `map-algo.c` (`mb_map` + `mb_map_batch`) and `map-main.c` (streaming `worker_for_se_batch`). CLI option codes are 312 / 313 (310 and 311 are taken by `--meth` and `--hic` on this branch).

Follow-up to #10 (Pass-2 sub-SMEM reseeding reduces MAPQ60 recall).

## Stacked on #11

This PR is stacked on top of #11 (`fix(map): drop is_pe param from mb_map_batch definition` + minimal build CI). Once #11 merges, GitHub will retarget this PR onto `master` automatically. The base branch is `fix/mb-map-batch-is-pe-build-break` so CI on this PR exercises the ablation feature on top of a buildable tree.

## Empirical measurement

WGS-1M R1-only against GRCh38 (1,000,000 SE Illumina reads, hs38 ref, 8 threads):

|                       | Pass-2 ON (default) | Pass-2 OFF (`--max-sub-occ=0`) | predA (`--min-sub-occ=2`) |
| ---                   | ---                 | ---                             | ---                        |
| Wall                  | 14.6 s              | 6.4 s                           | 12.4 s                     |
| CPU                   | 54.5 s              | 33.0 s                          | 39.6 s                     |
| shift60 vs ON         | -                   | 34,675 reads                    | 316 of 34,675 (0.91%)      |

`shift60` = same-placement reads where Pass-2 ON deflates MAPQ from 60 to <60. The lower-bound predicate preserves only 0.91% of those deflations -- the dominant case is "uniquely-seeded SMEM with paralog signal hidden inside it" -- so `--min-sub-occ` is a measurement knob, not a recommended production setting.

## Test plan

- [x] `make` and `make -C api-test` build clean
- [x] `minibwa map --help` lists `--max-sub-occ=INT [10]` and `--min-sub-occ=INT [1]`
- [x] On `test/chrM-human.fa.gz`, output is bit-identical between `minibwa map -a` and `minibwa map -a --max-sub-occ=10 --min-sub-occ=1` (defaults preserve master's behavior; chrM is too small to exercise Pass-2 deflation)
- [x] Empirical numbers above reproduced from prior implementation
- [ ] CI green on this PR