### PR TITLE
feat(align): 5'/3' soft-clip penalty (-L)

### DIFF
--- a/align.c
+++ b/align.c
@@ -326,10 +326,11 @@ static inline int32_t max_bw_from_mm(const mb_opt_t *opt, int32_t mm)
 }
 
 static void mb_align_pair(void *km, const mb_opt_t *opt, int qlen, const uint8_t *qseq, int tlen, const uint8_t *tseq,
-						  const int8_t *mat, int w, int end_bonus, int zdrop, int ksw_flag, ksw_extz_t *ez)
+						  const int8_t *mat, int w, int end_bonus, int pen_clip, int zdrop, int ksw_flag, ksw_extz_t *ez)
 {
 	const int max_bw_adj_len = 100; // don't adjust bandwidth if sequences are too long
 	int32_t j, n_mm = -1;
+	int eff_end_bonus = end_bonus >= 0? end_bonus + pen_clip : end_bonus; // -1 sentinel = no bonus
 	if ((opt->b_ts != 0 && opt->b != opt->b_ts) || (opt->flag&MB_F_METH))
 		ksw_flag |= KSW_EZ_GENERIC_SC;
 	if ((ksw_flag & KSW_EZ_EXTZ_ONLY) && tlen >= qlen) { // ungapped extension
@@ -341,7 +342,7 @@ static void mb_align_pair(void *km, const mb_opt_t *opt, int qlen, const uint8_t
 		}
 		if (n_mm <= 2) {
 			ez->mqe = ez->score, ez->mqe_t = qlen - 1;
-			if (ez->mqe + end_bonus >= ez->max) {
+			if (ez->mqe + eff_end_bonus >= ez->max) {
 				ez->reach_end = 1;
 				ez->cigar = ksw_push_cigar(km, &ez->n_cigar, &ez->m_cigar, ez->cigar, MB_CIGAR_MATCH, qlen);
 				return;
@@ -370,9 +371,9 @@ static void mb_align_pair(void *km, const mb_opt_t *opt, int qlen, const uint8_t
 		ksw_reset_extz(ez);
 		ez->zdropped = 1;
 	} else if (opt->q == opt->q2 && opt->e == opt->e2) { // affine gap
-		ksw_extz2_sse(km, qlen, qseq, tlen, tseq, 5, mat, opt->q, opt->e, w, zdrop * opt->a, end_bonus, ksw_flag, ez);
+		ksw_extz2_sse(km, qlen, qseq, tlen, tseq, 5, mat, opt->q, opt->e, w, zdrop * opt->a, eff_end_bonus, ksw_flag, ez);
 	} else { // dual affine gap
-		ksw_extd2_sse(km, qlen, qseq, tlen, tseq, 5, mat, opt->q, opt->e, opt->q2, opt->e2, w, zdrop * opt->a, end_bonus, ksw_flag, ez);
+		ksw_extd2_sse(km, qlen, qseq, tlen, tseq, 5, mat, opt->q, opt->e, opt->q2, opt->e2, w, zdrop * opt->a, eff_end_bonus, ksw_flag, ez);
 		//fprintf(stderr, "D2\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n", tlen, qlen, !!(ksw_flag&KSW_EZ_EXTZ_ONLY), ez->max_t, ez->max_q, ez->max, ez->zdropped);
 	}
 	if (kom_dbg_flag & MB_DBG_ALN_SEQ) {
@@ -641,7 +642,7 @@ static void mb_align1(void *km, const mb_opt_t *opt, const mb_idx_t *mi, int qle
 		l2b_getseq(mi->l2b, tid, ts0, ts, tseq);
 		mb_seq_rev(qs - qs0, qseq);
 		mb_seq_rev(ts - ts0, tseq);
-		mb_align_pair(km, opt, qs - qs0, qseq, ts - ts0, tseq, mat, bw, opt->end_bonus, r->split_inv? opt->zdrop_inv : opt->zdrop, ksw_flag|KSW_EZ_EXTZ_ONLY|KSW_EZ_RIGHT|KSW_EZ_REV_CIGAR, ez);
+		mb_align_pair(km, opt, qs - qs0, qseq, ts - ts0, tseq, mat, bw, opt->end_bonus, opt->pen_clip5, r->split_inv? opt->zdrop_inv : opt->zdrop, ksw_flag|KSW_EZ_EXTZ_ONLY|KSW_EZ_RIGHT|KSW_EZ_REV_CIGAR, ez);
 		if (ez->n_cigar > 0) {
 			mb_append_cigar(r, ez->n_cigar, ez->cigar);
 			r->p->dp_score += ez->reach_end? ez->mqe : ez->max;
@@ -686,10 +687,10 @@ static void mb_align1(void *km, const mb_opt_t *opt, const mb_idx_t *mi, int qle
 			// perform alignment
 			qseq = &qseq0[rev][qs];
 			l2b_getseq(mi->l2b, tid, ts, te, tseq);
-			mb_align_pair(km, opt, qe - qs, qseq, te - ts, tseq, mat, bw1, -1, opt->zdrop, ksw_flag|KSW_EZ_APPROX_MAX, ez); // first pass: with approximate Z-drop
+			mb_align_pair(km, opt, qe - qs, qseq, te - ts, tseq, mat, bw1, -1, 0, opt->zdrop, ksw_flag|KSW_EZ_APPROX_MAX, ez); // first pass: with approximate Z-drop
 			// test Z-drop and inversion Z-drop
 			if ((zdrop_code = mm_test_zdrop(km, opt, qseq, tseq, ez->n_cigar, ez->cigar, mat, is_sr)) != 0)
-				mb_align_pair(km, opt, qe - qs, qseq, te - ts, tseq, mat, bw1, -1, zdrop_code == 2? opt->zdrop_inv : opt->zdrop, ksw_flag, ez); // second pass: lift approximate
+				mb_align_pair(km, opt, qe - qs, qseq, te - ts, tseq, mat, bw1, -1, 0, zdrop_code == 2? opt->zdrop_inv : opt->zdrop, ksw_flag, ez); // second pass: lift approximate
 			if (kom_dbg_flag & MB_DBG_AN_POS) fprintf(stderr, "AD\t%d\t%ld\t%ld\t%d\t%d\t%d\t%d\n", r->as, (long)ts, (long)te, qs, qe, zdrop_code, ez->zdropped);
 			// update CIGAR
 			if (ez->n_cigar > 0)
@@ -731,7 +732,7 @@ static void mb_align1(void *km, const mb_opt_t *opt, const mb_idx_t *mi, int qle
 	if (!dropped && qe < qe0 && te < te0) { // right extension
 		qseq = &qseq0[rev][qe];
 		l2b_getseq(mi->l2b, tid, te, te0, tseq);
-		mb_align_pair(km, opt, qe0 - qe, qseq, te0 - te, tseq, mat, bw, opt->end_bonus, opt->zdrop, ksw_flag|KSW_EZ_EXTZ_ONLY, ez);
+		mb_align_pair(km, opt, qe0 - qe, qseq, te0 - te, tseq, mat, bw, opt->end_bonus, opt->pen_clip3, opt->zdrop, ksw_flag|KSW_EZ_EXTZ_ONLY, ez);
 		if (ez->n_cigar > 0) {
 			mb_append_cigar(r, ez->n_cigar, ez->cigar);
 			r->p->dp_score += ez->reach_end? ez->mqe : ez->max;
@@ -788,7 +789,7 @@ static int mb_align1_inv(void *km, const mb_opt_t *opt, const mb_idx_t *mi, int 
 	mb_seq_rev(tl, tseq);
 	if (score < opt->min_dp_max * opt->a) goto end_align1_inv;
 	q_off = ql - (q_off + 1), t_off = tl - (t_off + 1);
-	mb_align_pair(km, opt, ql - q_off, qseq + q_off, tl - t_off, tseq + t_off, mat, (int)(opt->bw * 1.5), -1, opt->zdrop, KSW_EZ_EXTZ_ONLY, ez);
+	mb_align_pair(km, opt, ql - q_off, qseq + q_off, tl - t_off, tseq + t_off, mat, (int)(opt->bw * 1.5), -1, 0, opt->zdrop, KSW_EZ_EXTZ_ONLY, ez);
 	if (ez->n_cigar == 0) goto end_align1_inv; // should never be here
 	mb_append_cigar(r_inv, ez->n_cigar, ez->cigar);
 	r_inv->p->dp_score = ez->max;

--- a/map-main.c
+++ b/map-main.c
@@ -341,6 +341,7 @@ static int usage(FILE *fp, const mb_opt_t *opt)
 	fprintf(fp, "    -O INT1[,INT2]   gap open penalty [%d,%d]\n", opt->q, opt->q2);
 	fprintf(fp, "    -E INT1[,INT2]   gap extension penalty [%d,%d]\n", opt->e, opt->e2);
 	fprintf(fp, "    -s INT           suppress alignment with DP score lower than INT*{-A} [%d]\n", opt->min_dp_max);
+	fprintf(fp, "    -L INT[,INT]     5'/3' soft-clip penalty (extend through noisy ends if `mqe + end_bonus + L >= max`) [%d,%d]\n", opt->pen_clip5, opt->pen_clip3);
 	fprintf(fp, "  Paired-end:\n");
 	fprintf(fp, "    -P               skip pairing and mate resuce\n");
 	fprintf(fp, "    --rescue=INT     mate rescue for up to INT candidates; 0 to skip rescue [%d]\n", opt->max_rescue);
@@ -372,7 +373,7 @@ static inline void yes_or_no(mb_opt_t *opt, uint64_t flag, int long_idx, const c
 
 int main_map(int argc, char *argv[])
 {
-	const char *opt_str = "x:o:k:c:m:p:A:B:U:b:O:E:t:K:N:PyYR:aul:w:W:g:5s:";
+	const char *opt_str = "x:o:k:c:m:p:A:B:U:b:O:E:L:t:K:N:PyYR:aul:w:W:g:5s:";
 	int32_t c;
 	mb_idx_t *idx;
 	mb_opt_t mo;
@@ -415,6 +416,10 @@ int main_map(int argc, char *argv[])
 		else if (c == '5') mo.flag |= MB_F_PRIMARY5;
 		else if (c == 'P') mo.flag |= MB_F_NO_PAIRING;
 		else if (c == 's') mo.min_dp_max = atoi(o.arg);
+		else if (c == 'L') {
+			mo.pen_clip5 = mo.pen_clip3 = strtol(o.arg, &s, 10);
+			if (*s == ',') mo.pen_clip3 = strtol(s + 1, &s, 10);
+		}
 		else if (c == 'o') fn_out = o.arg;
 		else if (c == 't') mo.n_thread = atoi(o.arg);
 		else if (c == 'R') rg_line = o.arg;

--- a/minibwa.1
+++ b/minibwa.1
@@ -276,6 +276,31 @@ A gap of length
 .I k
 costs
 .RI min( O1 + k * E1 , O2 + k * E2 ).
+.TP
+.B -L \fIINT1\fR[,\fIINT2\fR]
+5'- and 3'-end soft-clip penalty [0,0]. After the DP extension, the
+extend-to-end alignment is preferred over a clipped local-best
+alignment iff
+.RI ( mqe + end_bonus + L >= max ),
+where
+.I L
+is the relevant
+.B -L
+value (
+.I INT1
+for 5' /
+.I INT2
+for 3'). If
+.I INT2
+is not specified, it is set to
+.IR INT1 .
+Higher
+.I L
+makes the aligner more willing to extend through a noisy read tail
+rather than soft-clip it. Mirrors bwa-mem's
+.BR -L
+flag; default 0,0 preserves historical minibwa behavior (bwa-mem
+defaults to 5,5).
 
 .SS Paired-end Options
 .TP 10

--- a/minibwa.h
+++ b/minibwa.h
@@ -63,6 +63,7 @@ typedef struct {
 	int32_t q, q2;    // gap open, long gap open
 	int32_t e, e2;    // gap extension, long gap extension
 	int32_t end_bonus;
+	int32_t pen_clip5, pen_clip3; // 5'/3' soft-clip penalty (bwa-mem `-L`); extend-to-end is preferred to clipping iff mqe+end_bonus+pen_clip >= max
 	int32_t min_dp_max; // min_dp_max*a is the min score
 	int32_t zdrop;
 	int32_t zdrop_inv;

--- a/options.c
+++ b/options.c
@@ -24,6 +24,10 @@ static void mb_opt_reset(mb_opt_t *opt)
 	opt->q = 12, opt->q2 = 23;
 	opt->e = 2,  opt->e2 = 1;
 	opt->b_ambi = 1;
+	/* Default 0 to preserve historical minibwa extend/clip behavior; bwa-mem
+	 * default is 5,5 but enabling that as the minibwa default would shift
+	 * existing alignments unannounced. */
+	opt->pen_clip5 = opt->pen_clip3 = 0;
 	// pairing options
 	opt->max_pe_ins = 10000;
 	opt->max_rescue = 10;


### PR DESCRIPTION
## Summary

Adds a `-L INT[,INT]` flag mirroring bwa-mem's `-L`: a 5'/3' soft-clip penalty that lets the aligner prefer extension-to-end over a clipped local-best alignment iff `mqe + end_bonus + pen_clip >= max`.

- `pen_clip5` / `pen_clip3` added to `mb_opt_t`.
- `mb_align_pair` takes a new `pen_clip` argument and folds it into the `end_bonus` passed to `ksw_extz2_sse` / `ksw_extd2_sse`, so the CIGAR ksw2 emits matches the chosen end consistently. The branch in `mb_align_pair` that resolves `mqe` vs `max` for the ungapped fast path is updated to use the same `eff_end_bonus = end_bonus + pen_clip`.
- The five `mb_align_pair` call sites pass `opt->pen_clip5` (left/5' extension), `opt->pen_clip3` (right/3' extension), or `0` (middle / inversion).
- Single-value form (`-L 5`) sets both 5' and 3' to `5`; comma form (`-L 5,3`) sets them independently.

Default is `0,0` to preserve historical minibwa behavior — switching to bwa-mem's `5,5` default would silently shift existing alignments. Users who want bwa-mem-equivalent behavior can pass `-L 5,5` (or `-L 10` for the bwameth.py-style setting).

## Stacked on

This PR is stacked on top of #11 (`fix(map): drop is_pe param from mb_map_batch definition`) so it builds on top of master. The base will collapse to `master` once #11 lands.

## Test plan

- [x] `make` passes (macOS / clang)
- [x] `make -C api-test` passes
- [x] `./minibwa map -h` shows `-L INT[,INT] ... [0,0]`
- [x] Smoke alignment with `-L 0` (default), `-L 5,5`, and `-L 10` (single) on `test/chrM-*.fa.gz` — both parsing forms accepted; default output unchanged
- [ ] CI run is green at HEAD