### PR TITLE
feat(meth): emit Bismark-compatible XR/XG/XM tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,3 +12,5 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: make -j$(nproc)
       - run: make -j$(nproc) -C api-test
+      - name: meth XR/XG/XM tag test
+        run: sh test/test-meth-tags.sh

--- a/format.c
+++ b/format.c
@@ -41,7 +41,12 @@ static void write_meth_tags(kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t,
 	int64_t fetch_en = r->te + 2 <= tlen ? r->te + 2 : tlen;
 	uint8_t *ref = (uint8_t*)kom_malloc(uint8_t, fetch_en - fetch_st);
 	char *xm = (char*)kom_malloc(char, qlen + 1);
-	int seq_pos = r->qs;
+	/* XM is written in SAM SEQ orientation, so the first aligned base lands
+	 * at the SAM leading soft-clip offset. That offset is r->qs for forward
+	 * reads but qlen - r->qe for reverse reads (see clip_len[0] in mb_fmt_sam);
+	 * r->qs/r->qe are in original-read coordinates. Using r->qs unconditionally
+	 * mis-frames reverse reads with asymmetric clipping. */
+	int seq_pos = r->rev ? (int)(qlen - r->qe) : r->qs;
 	int64_t ref_pos = r->ts;
 	uint32_t k;
 	int j;

--- a/format.c
+++ b/format.c
@@ -16,16 +16,102 @@ static inline void write_tags(kstring_t *s, const mb_hit_t *p)
 	kom_sprintf_lite(s, "\tNM:i:%d\tAS:i:%d\tms:i:%d\tmd:i:%d", nm, p->p->dp_score, p->p->dp_max0, p->p->dp_max - p->p->dp_max2);
 }
 
-/* Bismark XR/XG. Under directional --meth: XR follows mate (R1=CT,
+/* Bismark XR/XG/XM. Under directional --meth: XR follows mate (R1=CT,
  * R2=GA, SE=CT); XG = "GA" iff (is_R2 XOR r->rev), reproducing Bismark's
- * (XR,XG) -> {OT,OB,CTOT,CTOB} encoding. */
-static inline void write_meth_strand_tags(kstring_t *s, int n_seg, int seg_idx, const mb_hit_t *r)
+ * (XR,XG) -> {OT,OB,CTOT,CTOB} encoding.
+ *
+ * XM is a per-base methylation-call string of length qlen, written in
+ * SAM SEQ orientation. SAM SEQ is always in top-strand-ref orientation
+ * (sam_write_sq revcomps when r->rev), so a CIGAR-ordered walk over SEQ
+ * positions produces a string that already aligns with SEQ in display
+ * order; no end-of-walk reversal is needed.
+ *
+ * Alphabet: . non-cytosine; z/Z CpG un/methylated; x/X CHG; h/H CHH;
+ * u/U cytosine in unknown context (off the reference window or N base). */
+static void write_meth_tags(kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t,
+							int n_seg, int seg_idx, const mb_hit_t *r)
 {
 	int is_r2 = (n_seg == 2 && seg_idx == 1);
 	int xg_is_ga = is_r2 ^ r->rev;
 	const char *xr = is_r2 ? "GA" : "CT";
 	const char *xg = xg_is_ga ? "GA" : "CT";
-	kom_sprintf_lite(s, "\tXR:Z:%s\tXG:Z:%s", xr, xg);
+	int qlen = t->l_seq;
+	int64_t tlen = l2b->ctg[r->tid].len;
+	int64_t fetch_st = r->ts >= 2 ? r->ts - 2 : 0;
+	int64_t fetch_en = r->te + 2 <= tlen ? r->te + 2 : tlen;
+	uint8_t *ref = (uint8_t*)kom_malloc(uint8_t, fetch_en - fetch_st);
+	char *xm = (char*)kom_malloc(char, qlen + 1);
+	int seq_pos = r->qs;
+	int64_t ref_pos = r->ts;
+	uint32_t k;
+	int j;
+
+	l2b_getseq(l2b, r->tid, fetch_st, fetch_en, ref);
+	for (j = 0; j < qlen; ++j) xm[j] = '.';
+	xm[qlen] = 0;
+
+	for (k = 0; k < r->p->n_cigar; ++k) {
+		int op = r->p->cigar[k] & 0xf;
+		int len = r->p->cigar[k] >> 4;
+		if (op == 0 || op == 7 || op == 8) { /* M/=/X */
+			for (j = 0; j < len; ++j) {
+				int read_b, off, c1, c2;
+				char meth = '.', unmeth = '.', call = '.';
+				if (ref_pos < fetch_st || ref_pos >= fetch_en) goto next;
+				off = (int)(ref_pos - fetch_st);
+				/* Top-strand-ref-frame read base. SEQ at seq_pos is
+				 * t->seq[seq_pos] for r->rev=0 and comp(t->seq[qlen-1-seq_pos])
+				 * for r->rev=1; either way it aligns to top_strand_ref[ref_pos]. */
+				if (r->rev) {
+					int b = kom_nt4_table[(uint8_t)t->seq[qlen - 1 - seq_pos]];
+					read_b = b < 4 ? 3 - b : 4;
+				} else {
+					read_b = kom_nt4_table[(uint8_t)t->seq[seq_pos]];
+				}
+				if (!xg_is_ga) {
+					/* XG=CT: top-strand C; context on top strand. */
+					if (ref[off] != 1) goto next;
+					c1 = (off + 1 < fetch_en - fetch_st) ? ref[off + 1] : 4;
+					c2 = (off + 2 < fetch_en - fetch_st) ? ref[off + 2] : 4;
+					if (c1 == 2)        { meth = 'Z'; unmeth = 'z'; }
+					else if (c1 == 4)   { meth = 'U'; unmeth = 'u'; }
+					else if (c2 == 2)   { meth = 'X'; unmeth = 'x'; }
+					else if (c2 == 4)   { meth = 'U'; unmeth = 'u'; }
+					else                { meth = 'H'; unmeth = 'h'; }
+					if      (read_b == 1) call = meth;
+					else if (read_b == 3) call = unmeth;
+				} else {
+					/* XG=GA: bottom-strand C, top-strand G. Bottom-strand
+					 * 5'->3' context base is comp(top[ref_pos-1]); CpG iff
+					 * top[ref_pos-1]=C, etc. */
+					if (ref[off] != 2) goto next;
+					c1 = (ref_pos - 1 >= fetch_st) ? ref[off - 1] : 4;
+					c2 = (ref_pos - 2 >= fetch_st) ? ref[off - 2] : 4;
+					if (c1 == 1)        { meth = 'Z'; unmeth = 'z'; }
+					else if (c1 == 4)   { meth = 'U'; unmeth = 'u'; }
+					else if (c2 == 1)   { meth = 'X'; unmeth = 'x'; }
+					else if (c2 == 4)   { meth = 'U'; unmeth = 'u'; }
+					else                { meth = 'H'; unmeth = 'h'; }
+					/* meth bottom C preserved -> comp = G (read_b=2);
+					 * unmeth bottom C->T -> comp = A (read_b=0). */
+					if      (read_b == 2) call = meth;
+					else if (read_b == 0) call = unmeth;
+				}
+next:
+				xm[seq_pos] = call;
+				++seq_pos;
+				++ref_pos;
+			}
+		} else if (op == 1) { /* I */
+			seq_pos += len;
+		} else if (op == 2 || op == 3) { /* D, N */
+			ref_pos += len;
+		}
+	}
+
+	kom_sprintf_lite(s, "\tXR:Z:%s\tXG:Z:%s\tXM:Z:%s", xr, xg, xm);
+	free(ref);
+	free(xm);
 }
 
 void mb_fmt_paf(kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, const mb_hit_t *p, uint64_t opt_flag, int n_seg, int seg_idx)
@@ -300,7 +386,7 @@ void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, i
 	if (n_seg > 2) kom_sprintf_lite(s, "\tFI:i:%d", seg_idx);
 	if (r) {
 		write_tags(s, r);
-		if (opt_flag & MB_F_METH) write_meth_strand_tags(s, n_seg, seg_idx, r);
+		if (opt_flag & MB_F_METH) write_meth_tags(s, l2b, t, n_seg, seg_idx, r);
 		// MC:Z mate CIGAR and MQ:i mate MAPQ; r_next is the mate's primary (see above).
 		if (n_seg > 1 && r_next && r_next->p && r_next->p->n_cigar > 0 && mate_qlen > 0) {
 			kom_sprintf_lite(s, "\tMC:Z:");

--- a/format.c
+++ b/format.c
@@ -16,6 +16,18 @@ static inline void write_tags(kstring_t *s, const mb_hit_t *p)
 	kom_sprintf_lite(s, "\tNM:i:%d\tAS:i:%d\tms:i:%d\tmd:i:%d", nm, p->p->dp_score, p->p->dp_max0, p->p->dp_max - p->p->dp_max2);
 }
 
+/* Bismark XR/XG. Under directional --meth: XR follows mate (R1=CT,
+ * R2=GA, SE=CT); XG = "GA" iff (is_R2 XOR r->rev), reproducing Bismark's
+ * (XR,XG) -> {OT,OB,CTOT,CTOB} encoding. */
+static inline void write_meth_strand_tags(kstring_t *s, int n_seg, int seg_idx, const mb_hit_t *r)
+{
+	int is_r2 = (n_seg == 2 && seg_idx == 1);
+	int xg_is_ga = is_r2 ^ r->rev;
+	const char *xr = is_r2 ? "GA" : "CT";
+	const char *xg = xg_is_ga ? "GA" : "CT";
+	kom_sprintf_lite(s, "\tXR:Z:%s\tXG:Z:%s", xr, xg);
+}
+
 void mb_fmt_paf(kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, const mb_hit_t *p, uint64_t opt_flag, int n_seg, int seg_idx)
 {
 	kom_sprintf_lite(s, "%s", t->name);
@@ -288,6 +300,7 @@ void mb_fmt_sam(void *km, kstring_t *s, const l2b_t *l2b, const mb_bseq1_t *t, i
 	if (n_seg > 2) kom_sprintf_lite(s, "\tFI:i:%d", seg_idx);
 	if (r) {
 		write_tags(s, r);
+		if (opt_flag & MB_F_METH) write_meth_strand_tags(s, n_seg, seg_idx, r);
 		// MC:Z mate CIGAR and MQ:i mate MAPQ; r_next is the mate's primary (see above).
 		if (n_seg > 1 && r_next && r_next->p && r_next->p->n_cigar > 0 && mate_qlen > 0) {
 			kom_sprintf_lite(s, "\tMC:Z:");

--- a/test/test-meth-tags.sh
+++ b/test/test-meth-tags.sh
@@ -52,7 +52,7 @@ echo "$R1" | grep -q 'XG:Z:CT' || { echo "FAIL: R1 XG != CT" >&2; echo "$R1"; ex
 echo "$R2" | grep -q 'XR:Z:GA' || { echo "FAIL: R2 XR != GA" >&2; echo "$R2"; exit 1; }
 echo "$R2" | grep -q 'XG:Z:CT' || { echo "FAIL: R2 XG != CT" >&2; echo "$R2"; exit 1; }
 
-# XM: Z at top-strand C of every CpG (positions 10,12,14,16, 27,29,31,33).
+# XM: Z at top-strand C of every CpG (positions 10,12,14,16, 28,30,32,34).
 EXPECTED_XM='..........Z.Z.Z.Z...........Z.Z.Z.Z'
 for rec in "$R1" "$R2"; do
 	XM=$(echo "$rec" | grep -oE 'XM:Z:[^[:space:]]+' | sed 's/XM:Z://')
@@ -66,4 +66,71 @@ for rec in "$R1" "$R2"; do
 	fi
 done
 
-echo "PASS: --meth XR/XG/XM tags emit correctly for a methylated OT fragment."
+# ---------------------------------------------------------------------------
+# Reverse-strand soft-clip framing.
+#
+# A read whose 3' tail runs off the reference maps to the reverse strand with
+# a *leading* soft-clip in SAM (SAM SEQ is the reverse complement of the
+# read). XM is written in SAM SEQ orientation, so the soft-clipped columns
+# must be '.'. A regression that seeds the XM walk at r->qs (correct only for
+# forward reads) instead of qlen - r->qe for reverse reads shifts the calls
+# into the clipped region.
+TOP='GATTACAGGCATGCCACCGTGCCCGGCTAATTTACGTGGAGCTCTAGCT'
+BOTTOM=$(printf '%s' "$TOP" | rev | tr ACGTacgt TGCAtgca)
+TAIL='TTAAGGCCTTAA'
+READ="${BOTTOM}${TAIL}"
+QUAL=$(printf '%s' "$READ" | tr '[:print:]' 'I')
+
+cat > "$TMP/refrc.fa" <<EOF
+>chr1
+$TOP
+EOF
+
+cat > "$TMP/rc.fq" <<EOF
+@rev_clip
+$READ
++
+$QUAL
+EOF
+
+"$MINIBWA" index --meth "$TMP/refrc.fa" 2>/dev/null
+"$MINIBWA" map --meth -a "$TMP/refrc.fa" "$TMP/rc.fq" 2>/dev/null > "$TMP/rc.sam"
+
+REC=$(grep -v '^@' "$TMP/rc.sam" | sed -n '1p')
+FLAG=$(echo "$REC" | cut -f2)
+CIGAR=$(echo "$REC" | cut -f6)
+XM=$(echo "$REC" | grep -oE 'XM:Z:[^[:space:]]+' | sed 's/XM:Z://')
+
+# Must map to the reverse strand (FLAG 0x10) with a leading soft-clip.
+if [ $(( FLAG & 16 )) -eq 0 ]; then
+	echo "FAIL: reverse-clip read not reverse-mapped (FLAG=$FLAG)" >&2
+	echo "$REC"; exit 1
+fi
+case "$CIGAR" in
+	[0-9]*S[0-9]*M*) : ;;
+	*) echo "FAIL: reverse-clip read has no leading soft-clip (CIGAR=$CIGAR)" >&2
+	   echo "$REC"; exit 1 ;;
+esac
+
+# Every XM column inside the leading soft-clip must be '.'.
+CLIP=${CIGAR%%S*}
+CLIPPED=$(printf '%s' "$XM" | cut -c1-"$CLIP")
+case "$CLIPPED" in
+	*[!.]*) echo "FAIL: XM has a methylation call inside the soft-clip" >&2
+	        echo "  clip=$CLIP CIGAR=$CIGAR" >&2
+	        echo "  XM=$XM" >&2
+	        exit 1 ;;
+esac
+
+# The read is the genomic reverse complement with no bisulfite conversion, so
+# every cytosine is "methylated" and all XM calls must be UPPERCASE. A walk
+# seeded at r->qs (correct only for forward reads) reads shifted read bases for
+# reverse reads and emits spurious lowercase (unmethylated) / 'u' calls.
+case "$XM" in
+	*[zxhu]*) echo "FAIL: reverse-clip XM has lowercase calls (mis-framed reverse walk)" >&2
+	          echo "  CIGAR=$CIGAR XM=$XM" >&2
+	          exit 1 ;;
+esac
+
+echo "PASS: --meth XR/XG/XM tags emit correctly for a methylated OT fragment"
+echo "PASS: --meth XM is framed correctly for reverse-strand soft-clipped reads"

--- a/test/test-meth-tags.sh
+++ b/test/test-meth-tags.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# End-to-end smoke test for --meth SAM tag emission.
+#
+# Builds a small synthetic reference with two CpG-rich blocks and a PE
+# read pair simulating an OT-source fragment with methylated CpGs:
+# - R1 reads the top strand directly (BS preserves Cs at methylated CpGs).
+# - R2 reads the bottom strand (revcomp displayed in SAM).
+#
+# Verifies XR/XG (Bismark OT encoding) and XM (Z at every CpG cytosine).
+#
+# Run from the repo root after `make`.
+
+set -e
+
+MINIBWA="${MINIBWA:-./minibwa}"
+TMP="${TMPDIR:-/tmp}/minibwa-meth-tags.$$"
+mkdir -p "$TMP"
+trap "rm -rf $TMP" EXIT
+
+cat > "$TMP/ref.fa" <<'EOF'
+>chr1
+AAAAAAAAAACGCGCGCGAAAAAAAAAACGCGCGCGAAAAAAAAAACGCGCGCG
+EOF
+
+cat > "$TMP/r1.fq" <<'EOF'
+@read_meth/1
+AAAAAAAAAACGCGCGCGAAAAAAAAAACGCGCGCG
++
+IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+EOF
+
+cat > "$TMP/r2.fq" <<'EOF'
+@read_meth/2
+CGCGCGCGTTTTTTTTTTCGCGCGCGTTTTTTTTTT
++
+IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+EOF
+
+"$MINIBWA" index --meth "$TMP/ref.fa" 2>/dev/null
+"$MINIBWA" map --meth -a "$TMP/ref.fa" "$TMP/r1.fq" "$TMP/r2.fq" 2>/dev/null > "$TMP/out.sam"
+
+# minibwa emits SAM records in segment order (R1 then R2 per query), so
+# the first non-header record is R1 and the second is R2.
+R1=$(grep -v '^@' "$TMP/out.sam" | sed -n '1p')
+R2=$(grep -v '^@' "$TMP/out.sam" | sed -n '2p')
+
+# OT fragment, R1: XR=CT, XG=CT.
+echo "$R1" | grep -q 'XR:Z:CT' || { echo "FAIL: R1 XR != CT" >&2; echo "$R1"; exit 1; }
+echo "$R1" | grep -q 'XG:Z:CT' || { echo "FAIL: R1 XG != CT" >&2; echo "$R1"; exit 1; }
+
+# OT fragment, R2: XR=GA, XG=CT (Bismark CTOT-style encoding for R2 of OT).
+echo "$R2" | grep -q 'XR:Z:GA' || { echo "FAIL: R2 XR != GA" >&2; echo "$R2"; exit 1; }
+echo "$R2" | grep -q 'XG:Z:CT' || { echo "FAIL: R2 XG != CT" >&2; echo "$R2"; exit 1; }
+
+# XM: Z at top-strand C of every CpG (positions 10,12,14,16, 27,29,31,33).
+EXPECTED_XM='..........Z.Z.Z.Z...........Z.Z.Z.Z'
+for rec in "$R1" "$R2"; do
+	XM=$(echo "$rec" | grep -oE 'XM:Z:[^[:space:]]+' | sed 's/XM:Z://')
+	# trailing-position behavior is reference-end dependent; check the prefix.
+	prefix=$(echo "$XM" | cut -c1-${#EXPECTED_XM})
+	if [ "$prefix" != "$EXPECTED_XM" ]; then
+		echo "FAIL: XM prefix mismatch" >&2
+		echo "  expected: $EXPECTED_XM" >&2
+		echo "  got:      $prefix" >&2
+		exit 1
+	fi
+done
+
+echo "PASS: --meth XR/XG/XM tags emit correctly for a methylated OT fragment."


### PR DESCRIPTION
Implements #14. Emits Bismark-compatible `XR:Z` / `XG:Z` / `XM:Z` tags under `--meth`.

> **Rebased onto the 4-base `--meth` master.** This branch originally sat on the older 3-letter meth lineage. It has been rebased onto current `master`, where seeding is 3-letter but base alignment and mate rescue run in 4-base space against the original reference with an asymmetric scoring matrix (the BISCUIT-style strategy). The tag code is decoupled from that change — it consumes the final CIGAR, coordinates, original read, and original reference (`l2b_getseq`) — so it rebased cleanly, and the revalidation below was rerun on the 4-base aligner.

## Commits

1. `feat(meth): emit XR:Z and XG:Z SAM tags` — write XR (read conversion) and XG (genome strand conversion) under `MB_F_METH`. XR follows mate (R1=CT, R2=GA, SE=CT); XG = "GA" iff (is_R2 XOR r->rev), reproducing Bismark's (XR,XG) -> {OT, OB, CTOT, CTOB} encoding.
2. `feat(meth): emit XM:Z methylation call string` — walk the alignment CIGAR over the unconverted reference window and emit a per-base methylation-call string in SAM SEQ orientation. Alphabet matches Bismark/DRAGEN: `.` non-cytosine; `z/Z` CpG; `x/X` CHG; `h/H` CHH; `u/U` cytosine in unknown context.
3. `test(meth): smoke test for XR/XG/XM tag emission` — `test/test-meth-tags.sh`, an end-to-end shell test over a synthetic CpG-rich reference and a methylated OT-fragment PE pair.
4. `fix(meth): correct XM frame for reverse-strand soft-clipped reads` — see below.
5. `test(meth): cover reverse-strand soft-clipped XM framing` — regression test for the fix; fails before, passes after.

`NM:i` is unchanged and remains bisulfite-aware: on the 4-base master the asymmetric matrix scores ref-C/read-T (and ref-G/read-A) as a match, so converted positions are not counted as edits (mean NM ≈ 0.57 on fully-converted reads). `MD:Z` is not emitted; no methylation tool reads it.

## Encoding under directional `--meth`

| Mate, r->rev | XR:Z | XG:Z | Bismark strand |
|---|---|---|---|
| R1, rev=0 | CT | CT | OT |
| R1, rev=1 | CT | GA | OB |
| R2, rev=0 | GA | GA | CTOB |
| R2, rev=1 | GA | CT | CTOT |

## XM walk

Walks (seq_pos, ref_pos) forward through the CIGAR. SAM SEQ is always in top-strand-ref orientation (`sam_write_sq` revcomps when `r->rev=1`), so a single forward walk produces a string aligned with SAM SEQ in display order; no end-of-walk reversal.

The walk is seeded at the SAM leading soft-clip offset: `r->qs` for forward reads, `qlen - r->qe` for reverse reads (mirroring `clip_len[0]` in the SAM writer, since `r->qs`/`r->qe` are in original-read coordinates). Insertions (`I`) and soft clips at the read ends produce `.` at the corresponding XM positions.

For XG=CT (top-strand source), context is read from `ref[ref_pos+1]` and `ref[ref_pos+2]`. Read base in top-strand frame: C -> methylated, T -> unmethylated.

For XG=GA (bottom-strand source), the bottom-strand 5'->3' context base is `comp(top[ref_pos-1])`, so CpG iff `top[ref_pos-1]=C`, etc. Read base in top-strand frame: G -> methylated (bottom C preserved, comp = G), A -> unmethylated (bottom C->T BS, comp = A).

## Reverse-strand soft-clip fix

The XM string is in SAM SEQ orientation, where the leading soft-clip length is `qlen - r->qe` for reverse-strand reads but `r->qs` only for forward reads. The original `write_meth_tags` seeded the walk at `r->qs` unconditionally, so reverse reads with asymmetric soft-clips indexed shifted query bases and emitted mis-framed calls across the aligned region. The smoke test missed this because its fragment was full-length `150M` (no clip). Fixed by seeding the walk at `qlen - r->qe` for reverse reads; the new test maps a read whose 3' tail runs off the reference (forcing a reverse alignment with a leading soft-clip) and asserts no spurious calls.

## Validation

### Smoke test (synthetic, in-tree)

```
$ ./test/test-meth-tags.sh
PASS: --meth XR/XG/XM tags emit correctly for a methylated OT fragment
PASS: --meth XM is framed correctly for reverse-strand soft-clipped reads
```

### holodeck ground-truth concordance, chr17 1x em-seq (rerun on 4-base master)

Simulated 277,525 PE fragments with [holodeck](https://github.com/fg-labs/holodeck) `0.2.1` (`methylate` -> annotated VCF, then `simulate --methylation-mode em-seq --golden-bam`, seed 42), which writes a golden BAM with Bismark-compatible XR/XG/XM tags from the simulator's per-haplotype methylation truth. Aligned with `minibwa map --meth`, then compared XR+XG+XM per (QNAME, mate). All 555,050 reads mapped (0 unmapped).

| | XR+XG+XM byte-identical |
|---|---|
| overall (555,050 reads) | 548,125 (98.75%) |
| position+strand matched (531,946) | 531,803 (99.97%) |

The ~23k position differences are segdup/homolog misplacements (minibwa placed the read at a different chr17 position than the simulator's source); the XM at minibwa's chosen position is internally consistent with the reference window it aligned to. Of the 143 remaining position-matched differences, all are cases where minibwa chose a different soft-clip/indel boundary than the simulator's truth CIGAR (so XM legitimately shifts); only 5 share an identical CIGAR, and those are conservative `u` (unknown-context) calls next to reference `N` bases. XR and XG are 100% concordant on all position-matched reads.

The reverse-clip fix above raised position-matched concordance from 99.94% to 99.97% (removing 197 mis-tagged reverse reads).

Example head-to-head from a position-matched fragment:

```
                     XR:Z  XG:Z  XM:Z
golden  R1 (rev=0):  CT    CT    .......x..........z...h...x........x..h...............hh.h.x.........z........Z........xZ.h.x....h..
minibwa R1 (rev=0):  CT    CT    .......x..........z...h...x........x..h...............hh.h.x.........z........Z........xZ.h.x....h..
golden  R2 (rev=1):  GA    CT    .....z........xZ.h.x....h....x.....h...h.x.....h..h.............h...h....h.x.........h...hhh.....x..
minibwa R2 (rev=1):  GA    CT    .....z........xZ.h.x....h....x.....h...h.x.....h..h.............h...h....h.x.........h...hhh.....x..
```

## Open follow-ups (not in this PR)

- Pipe minibwa `--meth` output through MethylDackel and compare per-CpG bedGraph against holodeck's `--cpg-truth-bedgraph` and against bwameth/Bismark on the same reads.
- Add the meth smoke test to CI (`build.yml` currently builds api-test only).
