### PR TITLE
add a --meth CI test and document two scoring details

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,3 +12,5 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: make -j$(nproc)
       - run: make -j$(nproc) -C api-test
+      - name: meth alignment functional test
+        run: sh test/test-meth-align.sh

--- a/align.c
+++ b/align.c
@@ -773,7 +773,12 @@ static int mb_align1_inv(void *km, const mb_opt_t *opt, const mb_idx_t *mi, int 
 	if (ql < opt->min_chain_score || ql > opt->max_gap) return 0;
 	if (tl < opt->min_chain_score || tl > opt->max_gap) return 0;
 
-	if (!r1->rev) mt = l2b_meth_rev(mt); // TODO: check if this is correct
+	// mt is the read's base conversion (same value passed to mb_align1, which
+	// flips it locally for its own segment via `if (r->rev)`). The inverted
+	// segment maps to strand r_inv->rev = !r1->rev, so flip the conversion when
+	// !r1->rev, mirroring the mb_align1 / mb_matesw_core convention of flipping
+	// mt whenever the aligned segment is reverse-strand.
+	if (!r1->rev) mt = l2b_meth_rev(mt);
 	ksw_gen_nt4_mat(mat, opt->a, opt->b, opt->b_ts, opt->b_ambi, (int)mt);
 
 	tseq = (uint8_t*)kmalloc(km, tl);

--- a/minibwa.h
+++ b/minibwa.h
@@ -58,7 +58,7 @@ typedef struct {
 	int32_t best_n;
 	// alignment options
 	int32_t a, b;     // match, mismatch
-	int32_t b_ts;     // transition mismatch
+	int32_t b_ts;     // transition mismatch penalty; 0 by default and no CLI flag, so inactive unless set programmatically (meth mode still forces the C>T/G>A cell to a match via mt)
 	int32_t b_ambi;   // ambiguous mismatch
 	int32_t q, q2;    // gap open, long gap open
 	int32_t e, e2;    // gap extension, long gap extension

--- a/test/test-meth-align.sh
+++ b/test/test-meth-align.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Functional test for --meth bisulfite alignment.
+#
+# Bisulfite-converts the bundled chrM reads (R1 C->T, R2 G->A) to simulate a
+# fully-unmethylated directional library, then maps them with --meth. The
+# asymmetric scoring matrix must tolerate the conversions, so converted reads
+# align near full length with low edit distance. As a control, mapping the same
+# converted reads WITHOUT --meth degrades badly (conversions read as
+# mismatches), so meth mode must be clearly better.
+#
+# Run from the repo root after `make`.
+
+set -e
+
+MINIBWA="${MINIBWA:-./minibwa}"
+TMP="${TMPDIR:-/tmp}/minibwa-meth-align.$$"
+mkdir -p "$TMP"
+trap "rm -rf $TMP" EXIT
+
+gzip -dc test/chrM-human.fa.gz > "$TMP/ref.fa"
+# Bisulfite-convert sequence lines only (FASTA = alternating header/seq lines).
+gzip -dc test/chrM-read_1.fa.gz | awk 'NR%2==0{gsub(/[Cc]/,"T")}1' > "$TMP/bs_1.fa"
+gzip -dc test/chrM-read_2.fa.gz | awk 'NR%2==0{gsub(/[Gg]/,"A")}1' > "$TMP/bs_2.fa"
+
+"$MINIBWA" index "$TMP/ref.fa" 2>/dev/null
+"$MINIBWA" index --meth "$TMP/ref.fa" 2>/dev/null
+
+"$MINIBWA" map -a --meth "$TMP/ref.fa" "$TMP/bs_1.fa" "$TMP/bs_2.fa" 2>/dev/null > "$TMP/meth.sam"
+"$MINIBWA" map -a        "$TMP/ref.fa" "$TMP/bs_1.fa" "$TMP/bs_2.fa" 2>/dev/null > "$TMP/norm.sam"
+
+# Mean NM and primary-alignment count over a SAM file.
+# Prints "<count> <mean_nm>".
+nm_stats () {
+	grep -v '^@' "$1" | awk '{
+		flag = $2
+		if (int(flag/256)%2 || int(flag/2048)%2) next   # skip secondary/supplementary
+		if (int(flag/4)%2) next                          # skip unmapped
+		for (i = 12; i <= NF; ++i)
+			if ($i ~ /^NM:i:/) { split($i, a, ":"); s += a[3]; ++n }
+	} END { printf "%d %.3f", n, (n ? s/n : 999) }'
+}
+
+set -- $(nm_stats "$TMP/meth.sam"); METH_N=$1; METH_NM=$2
+set -- $(nm_stats "$TMP/norm.sam"); NORM_N=$1; NORM_NM=$2
+
+echo "  --meth : $METH_N primary alns, mean NM $METH_NM"
+echo "  normal : $NORM_N primary alns, mean NM $NORM_NM"
+
+# At least 95% of the 2000 reads must map in meth mode.
+if [ "$METH_N" -lt 1900 ]; then
+	echo "FAIL: --meth mapped only $METH_N/2000 reads" >&2; exit 1
+fi
+# Converted reads must align cleanly under the asymmetric matrix.
+if ! awk -v v="$METH_NM" 'BEGIN{exit !(v < 2.0)}'; then
+	echo "FAIL: --meth mean NM ($METH_NM) too high; bisulfite tolerance broken" >&2; exit 1
+fi
+# ...and clearly beat plain mapping of the same converted reads.
+if ! awk -v m="$METH_NM" -v n="$NORM_NM" 'BEGIN{exit !(n > m*3)}'; then
+	echo "FAIL: --meth ($METH_NM) not clearly better than normal ($NORM_NM)" >&2; exit 1
+fi
+
+echo "PASS: --meth aligns bisulfite-converted reads with low edit distance"

--- a/test/test-meth-align.sh
+++ b/test/test-meth-align.sh
@@ -15,7 +15,7 @@ set -e
 MINIBWA="${MINIBWA:-./minibwa}"
 TMP="${TMPDIR:-/tmp}/minibwa-meth-align.$$"
 mkdir -p "$TMP"
-trap "rm -rf $TMP" EXIT
+trap 'rm -rf "$TMP"' EXIT
 
 gzip -dc test/chrM-human.fa.gz > "$TMP/ref.fa"
 # Bisulfite-convert sequence lines only (FASTA = alternating header/seq lines).


### PR DESCRIPTION
Three small `--meth`-related changes. No change to alignment output.

**1. Add a bisulfite alignment test to CI.** `build.yml` previously only built (plus `api-test`), with no functional coverage — so the recent 3-letter → 4-base meth rewrite had no regression net. `test/test-meth-align.sh` bisulfite-converts the bundled chrM reads (R1 C→T, R2 G→A), maps them with `--meth`, and asserts they align with low edit distance (mean NM < 2) and clearly beat plain mapping of the same converted reads (a regression to the non-meth path would spike NM and fail the test). Wired into the build workflow.

**2. Document the conversion-strand flip in `mb_align1_inv`.** Replaces the `// TODO: check if this is correct` at `align.c:775` with a comment. The flip is correct: `mt` is the read's base conversion (the same value `mb_align1` receives and flips locally per segment), and the inverted segment maps to strand `!r1->rev`, so flipping when `!r1->rev` mirrors the established `mb_align1` / `mb_matesw_core` convention of flipping `mt` whenever the aligned segment is reverse. Verified empirically: across 555,050 holodeck chr17 em-seq alignments, NM is 0–2 for 99.18% and never exceeds 10 — a wrong-strand bisulfite alignment would spike NM to 30–70.

**3. Note that `b_ts` is unset by default.** `opt->b_ts` (transition mismatch penalty) has no CLI flag and is never initialized (unlike `b_ambi`), so it stays 0 and the transition branch in `ksw_gen_nt4_mat` is inactive unless set programmatically. Documented in `minibwa.h` so the field isn't mistaken for a live knob.
