### PR TITLE
fix NEON casts in epi32 helpers

### DIFF
--- a/s2n-lite.h
+++ b/s2n-lite.h
@@ -49,8 +49,8 @@ static inline __m128i _mm_setr_epi32(int a, int b, int c, int d) {
 }
 static inline __m128i _mm_cmpgt_epi32(__m128i a, __m128i b) { return vreinterpretq_u8_u32(vcgtq_s32(vreinterpretq_s32_u8(a), vreinterpretq_s32_u8(b))); }
 static inline __m128i _mm_max_epi32(__m128i a, __m128i b) { return vreinterpretq_u8_s32(vmaxq_s32(vreinterpretq_s32_u8(a), vreinterpretq_s32_u8(b))); }
-static inline __m128i _mm_add_epi32(__m128i a, __m128i b) { return vreinterpretq_u8_s32(vaddq_u32(vreinterpretq_u32_u8(a), vreinterpretq_u32_u8(b))); }
-static inline __m128i _mm_sub_epi32(__m128i a, __m128i b) { return vreinterpretq_u8_s32(vsubq_u32(vreinterpretq_u32_u8(a), vreinterpretq_u32_u8(b))); }
+static inline __m128i _mm_add_epi32(__m128i a, __m128i b) { return vreinterpretq_u8_u32(vaddq_u32(vreinterpretq_u32_u8(a), vreinterpretq_u32_u8(b))); }
+static inline __m128i _mm_sub_epi32(__m128i a, __m128i b) { return vreinterpretq_u8_u32(vsubq_u32(vreinterpretq_u32_u8(a), vreinterpretq_u32_u8(b))); }
 
 #define _mm_insert_epi32(a, b, imm8) vreinterpretq_u8_s32(vsetq_lane_s32((b), vreinterpretq_s32_u8(a), (imm8)))
 


### PR DESCRIPTION
Hi!

Thank you for releasing minibwa.

I tried to add minibwa to [Homebrew](https://github.com/Homebrew/homebrew-core/pull/288395), but the ARM Linux build failed with the following error:

https://github.com/Homebrew/homebrew-core/actions/runs/27666084320/job/81820913332

```console
s2n-lite.h:52:89: error: incompatible type for argument 1 of ‘vreinterpretq_u8_s32’
s2n-lite.h:53:89: error: incompatible type for argument 1 of ‘vreinterpretq_u8_s32’
```

This PR aims to fixe a type mismatch in the NEON code in `s2n-lite.h`.

I confirmed with [GitHub Actions](https://github.com/kojix2/minibwa/actions/runs/27671493535/job/81836637101) that it now builds on [ARM Linux](https://github.com/kojix2/minibwa/blob/arm-linux/.github/workflows/build.yml).

Thank you.