### PR TITLE
Memory leak in .l2b file closing

### DIFF
--- a/l2bit.c
+++ b/l2bit.c
@@ -275,7 +275,10 @@ l2b_t *l2b_load(const char *fn)
 	fp = fn == 0 || strcmp(fn, "-") == 0? stdin : fopen(fn, "rb");
 	if (fp == 0) return 0;
 	fread(magic, 1, 4, fp);
-	if (strncmp(magic, L2B_MAGIC, 4) != 0) return 0;
+	if (strncmp(magic, L2B_MAGIC, 4) != 0) {
+		if (fp != stdin) fclose(fp);
+		return 0;
+	}
 	l2b = kom_calloc(l2b_t, 1);
 	fread(&dummy, 4, 1, fp);
 	fread(&l2b->n_ctg, 8, 1, fp);
@@ -311,8 +314,10 @@ l2b_t *l2b_load(const char *fn)
 		p_comm += *p_comm? strlen(p_comm) + 1 : 1;
 	}
 	if (p_name - l2b->cat_name != len_name || p_comm - l2b->cat_comm != len_comm) goto load_failure;
+	if (fp != stdin) fclose(fp);
 	return l2b;
 load_failure:
+	if (fp != stdin) fclose(fp);
 	l2b_destroy(l2b);
 	return 0;
 }


### PR DESCRIPTION
The .l2b file is not properly closed while running `minibwa`, leading to a small, once per call memory leak.

To demonstrate this I had claude write a small script that would cycle load-destroy over l2b.
```
#include <stdio.h>
#include <fcntl.h>
#include <string.h>
#include "l2bit.h"
#include "bwt.h"

static int count_open_fds(void) {
    int n = 0;
    for (int fd = 0; fd < 1024; ++fd)
        if (fcntl(fd, F_GETFD) != -1) ++n;
    return n;
}

// print fds that resolve to a path containing 'needle'
static void show_matching_fds(const char *needle) {
    char path[4096];
    for (int fd = 0; fd < 1024; ++fd)
        if (fcntl(fd, F_GETFD) != -1 && fcntl(fd, F_GETPATH, path) != -1)
            if (strstr(path, needle)) printf("      fd %d -> %s\n", fd, path);
}

int main(int argc, char **argv) {
    const char *l2b_fn = argv[1];
    int N = 8;

    printf("baseline open fds = %d\n\n", count_open_fds());

    printf("=== l2b_load / l2b_destroy x%d ===\n", N);
    for (int i = 0; i < N; ++i) {
        l2b_t *l = l2b_load(l2b_fn);
        l2b_destroy(l);
        printf("  after cycle %d: open fds = %d\n", i + 1, count_open_fds());
    }
    printf("  fds still pointing at the .l2b file:\n");
    show_matching_fds("ref.l2b");

    return 0;
}
```

It produced the following output:
```
baseline open fds = 3

=== l2b_load / l2b_destroy x8 (the suspect) ===
  after cycle 1: open fds = 4
  after cycle 2: open fds = 5
  after cycle 3: open fds = 6
  after cycle 4: open fds = 7
  after cycle 5: open fds = 8
  after cycle 6: open fds = 9
  after cycle 7: open fds = 10
  after cycle 8: open fds = 11
  fds still pointing at the .l2b file:
      fd 3 -> /private/tmp/ref.l2b
      fd 4 -> /private/tmp/ref.l2b
      fd 5 -> /private/tmp/ref.l2b
      fd 6 -> /private/tmp/ref.l2b
      fd 7 -> /private/tmp/ref.l2b
      fd 8 -> /private/tmp/ref.l2b
      fd 9 -> /private/tmp/ref.l2b
      fd 10 -> /private/tmp/ref.l2b
```

After patching changes, it correctly shows only 3 files:
```
baseline open fds = 3

=== l2b_load / l2b_destroy x8 (the suspect) ===
  after cycle 1: open fds = 3
  after cycle 2: open fds = 3
  after cycle 3: open fds = 3
  after cycle 4: open fds = 3
  after cycle 5: open fds = 3
  after cycle 6: open fds = 3
  after cycle 7: open fds = 3
  after cycle 8: open fds = 3
  fds still pointing at the .l2b file:
```