### PR TITLE
use memchr() for single-char delimiters in ks_getuntil2()

### DIFF
--- a/kseq.h
+++ b/kseq.h
@@ -115,11 +115,11 @@ typedef struct __kstring_t {
 				} else break; \
 			} \
 			if (delimiter == KS_SEP_LINE) { \
-				for (i = ks->begin; i < ks->end; ++i) \
-					if (ks->buf[i] == '\n') break; \
+				unsigned char *__nl = (unsigned char*)memchr(ks->buf + ks->begin, '\n', ks->end - ks->begin); \
+				i = __nl? (int)(__nl - ks->buf) : ks->end; \
 			} else if (delimiter > KS_SEP_MAX) { \
-				for (i = ks->begin; i < ks->end; ++i) \
-					if (ks->buf[i] == delimiter) break; \
+				unsigned char *__sep = (unsigned char*)memchr(ks->buf + ks->begin, delimiter, ks->end - ks->begin); \
+				i = __sep? (int)(__sep - ks->buf) : ks->end; \
 			} else if (delimiter == KS_SEP_SPACE) { \
 				for (i = ks->begin; i < ks->end; ++i) \
 					if (isspace(ks->buf[i])) break; \


### PR DESCRIPTION
The single-character delimiter branches of ks_getuntil2() (KS_SEP_LINE and a
literal char) scanned the buffer a byte at a time. Replacing those two loops
with memchr() speeds up parsing of long lines; the isspace() branches are left
unchanged. Behaviour is identical -- minibwa output is byte-for-byte the same
before and after (20M read pairs, hs38, two-file and interleaved input).

Timing of the scan alone (find the next '\n' at a given distance, ns/call):

  compiler        scalar    memchr
  clang 21         58.4       5.8     (151 B line)
  gcc 11.5         8.3 *      5.7
  gcc 15           5.7 *      5.7

  * gcc auto-vectorizes the byte loop; clang and older gcc do not, so the
    benefit depends on the compiler.

End to end, minibwa map on 20M pairs against hs38 (Graviton4, gcc 11.5):

  threads  input         base     memchr
  96       fastq.gz      56.3s    51.6s    (-8%, 5 reps, no overlap)
  16       fastq.gz      159.8s   159.5s   (unchanged)

The gain shows up when the single decompress+parse thread is the bottleneck
(many threads, gzip'd input); at low thread counts it is within noise.
