### PR TITLE
build mimalloc.o with -std=gnu11 so it interposes aligned_alloc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ endif
 all:$(PROG)
 
 mimalloc.o:
-		$(CC) -c -std=gnu99 -O3 -Wall -Wextra -DNDEBUG -DMI_MALLOC_OVERRIDE -DMI_OSX_INTERPOSE=1 -DMI_OSX_ZONE=1 -Imimalloc mimalloc/static.c -o $@
+		$(CC) -c -std=gnu11 -O3 -Wall -Wextra -DNDEBUG -DMI_MALLOC_OVERRIDE -DMI_OSX_INTERPOSE=1 -DMI_OSX_ZONE=1 -Imimalloc mimalloc/static.c -o $@
 
 libminibwa.a:$(LOBJS)
 		$(AR) -csru $@ $(LOBJS)


### PR DESCRIPTION
mimalloc's malloc override only defines its `aligned_alloc` interposer under `#if !defined(__GLIBC__) || __USE_ISOC11` (`mimalloc/alloc-override.c`). On glibc `__USE_ISOC11` is set only for a C11+ standard, so building `mimalloc.o` with `-std=gnu99` overrides `malloc`/`free`/`posix_memalign`/`memalign` but not `aligned_alloc`.

With the stock `-lz` this never matters — zlib doesn't call `aligned_alloc`. It does start to matter once a drop-in zlib-ng is linked: `zng_alloc` uses `aligned_alloc` when cmake detects `HAVE_ALIGNED_ALLOC`, so the inflate window/state is allocated by glibc `aligned_alloc` and later freed by mimalloc `free`. mimalloc's page-map has no record of the foreign pointer, so `mi_free` can dereference a NULL sub-map and SIGSEGV at teardown — intermittently (~40–50% of runs), depending on whether the 512 MB region happens to have a committed sub-map.

This came up while looking at bioconda/bioconda-recipes#66454, which statically links zlib-ng in `ZLIB_COMPAT` mode as a drop-in `libz` in place of `-lz` for a faster inflate at high thread counts, with no source changes to minibwa. That's a nice win. The relevant detail is that the recipe builds minibwa with `make` and no `mimalloc=1`, so the packaged binary keeps the default `MALLOC_O = mimalloc.o` — i.e. it pairs mimalloc with an `aligned_alloc`-using `libz`, which is exactly the combination that triggers the crash above. So this isn't just theoretical for that recipe; it's the as-shipped configuration. Fixing it here, rather than working around it in the recipe, keeps any drop-in-`libz` build of minibwa robust.

The fix is to build `mimalloc.o` with `-std=gnu11`, which routes `aligned_alloc` through mimalloc like the other allocator entry points, keeping every alloc/free pair consistent regardless of which `libz` is linked. It's a no-op for the stock zlib build.

Verified on arm64 (amazonlinux:2023): with a drop-in zlib-ng, a teardown crash loop goes from 17–18/40 to 0/40 at `-t 8/16/32`; SAM output is byte-identical and there's no perf change.
