### PR TITLE
README: add -f to the PAF example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cd minibwa && make
 ./minibwa map chrM-human test/chrM-read_?.fa.gz > aln.sam     # align and output in SAM
 
 # other examples without test data
-minibwa map -t16 ref.index long-read.fq > aln.paf             # align long reads
+minibwa map -ft16 ref.index long-read.fq > aln.paf            # align long reads
 minibwa map --hic ref.index reads.interleaved.fq > aln.sam    # align Hi-C short reads
 
 # align *directional* bisulfite sequencing (BS-seq) reads


### PR DESCRIPTION
The long-read example in Getting Started redirects to `aln.paf`, but since SAM became the default output (r361) the command writes SAM without `-f`. Add `-f`, matching the `-ft8` example in the manual section below.
