### PR TITLE
format SAM/PAF in the mapping step instead of the output thread

### DIFF
--- a/map-main.c
+++ b/map-main.c
@@ -118,8 +118,18 @@ static void worker_for_format(void *data, long i, int tid)
 	const mb_idx_t *idx = s->p->idx;
 	kstring_t *out = &s->str[i];
 	void *km = s->fmt_km[tid]; // per-thread kalloc pool, reused across this thread's superbatches
+	int64_t est = 0;
 	int32_t b, k, j;
 	out->l = 0;
+	// pre-size from the superbatch's bases (SEQ+QUAL ~ 2*l_seq) plus a fixed
+	// per-record allowance for the name and fields, so the per-field appends do
+	// not grow the buffer up from zero (which also rounds up to ~1.7x the size)
+	for (b = 0; b < s->sb_cnt[i]; ++b) {
+		int32_t frag = s->sb_off[i] + b;
+		for (k = s->seg_off[frag]; k < s->seg_off[frag] + s->seg_cnt[frag]; ++k)
+			est += 2 * (int64_t)s->seq[k].l_seq + 128;
+	}
+	if (est + 1 > (int64_t)out->m) { out->m = est + 1; out->s = kom_realloc(char, out->s, out->m); }
 	for (b = 0; b < s->sb_cnt[i]; ++b) {
 		int32_t frag = s->sb_off[i] + b;
 		int32_t seg_st = s->seg_off[frag], seg_en = s->seg_off[frag] + s->seg_cnt[frag];

--- a/map-main.c
+++ b/map-main.c
@@ -28,6 +28,8 @@ typedef struct {
 	mb_bseq1_t *seq;
 	mb_hit_t **hit;
 	mb_tbuf_t **tbuf;
+	kstring_t *str;       // per-superbatch SAM/PAF text, built in parallel (step 1), written in order (step 2)
+	void **fmt_km;        // per-thread kalloc pools for the parallel format pass
 } step_t;
 
 static void worker_for_se_batch(void *data, long i, int tid)
@@ -106,6 +108,43 @@ static void worker_for_pe(void *data, long i, int tid)
 	mb_pair(mb_tbuf_km(b), s->p->opt, s->p->idx->l2b, &s->n_hit[off], &s->hit[off], s->pes, len, seq);
 }
 
+// Format one superbatch worth of fragments into its own kstring. Each worker
+// touches only s->str[i], so the pass is thread-safe; the SAM/PAF text that was
+// previously built serially in step 2 is produced here in parallel instead.
+static void worker_for_format(void *data, long i, int tid)
+{
+	step_t *s = (step_t*)data;
+	const mb_opt_t *opt = s->p->opt;
+	const mb_idx_t *idx = s->p->idx;
+	kstring_t *out = &s->str[i];
+	void *km = s->fmt_km[tid]; // per-thread kalloc pool, reused across this thread's superbatches
+	int32_t b, k, j;
+	out->l = 0;
+	for (b = 0; b < s->sb_cnt[i]; ++b) {
+		int32_t frag = s->sb_off[i] + b;
+		int32_t seg_st = s->seg_off[frag], seg_en = s->seg_off[frag] + s->seg_cnt[frag];
+		for (k = seg_st; k < seg_en; ++k) {
+			mb_bseq1_t *t = &s->seq[k];
+			int32_t mate_qlen = 0; // mate's l_seq for MC:Z; 0 suppresses MC/MQ
+			if (seg_en - seg_st > 1) {
+				int32_t mate_idx = k != seg_en - 1? k + 1 : seg_st; // wrap around if k is the last segment
+				mate_qlen = s->seq[mate_idx].l_seq;
+			}
+			if (s->n_hit[k] > 0) { // the query has at least one hit
+				int32_t n_sec = 0;
+				for (j = 0; j < s->n_hit[k]; ++j) {
+					const mb_hit_t *h = &s->hit[k][j];
+					if (h->parent == h->id || n_sec < opt->out_n)
+						mb_format(km, out, idx->l2b, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], j, opt->flag, k - seg_st, mate_qlen);
+					n_sec += (h->parent != h->id);
+				}
+			} else if (!(opt->flag & MB_F_NO_UNMAP)) {
+				mb_format(km, out, idx->l2b, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], -1, opt->flag, k - seg_st, mate_qlen);
+			}
+		}
+	}
+}
+
 static void *worker_pipeline(void *shared, int step, void *in)
 {
 	const int min_read_cnt = 40000; // should be smaller than opt->mb_size / (read_len * 2) for typical paired-end reads
@@ -169,6 +208,7 @@ static void *worker_pipeline(void *shared, int step, void *in)
 			}
 			s->sb_off[s->n_sb] = sb_off;
 			s->sb_cnt[s->n_sb++] = i - sb_off;
+			s->str = kom_calloc(kstring_t, s->n_sb); // per-superbatch output buffers, filled in step 1
 			return s;
 		} else free(s);
     } else if (step == 1) { // step 1: map
@@ -187,44 +227,37 @@ static void *worker_pipeline(void *shared, int step, void *in)
 			}
 			kt_for(opt->n_thread, worker_for_pe, in, s->n_frag);
 		}
+		// build SAM/PAF text in parallel so step 2 is pure ordered I/O. one kalloc
+		// pool per thread (reused across superbatches) keeps mb_format off the
+		// shared allocator without per-superbatch init/destroy churn.
+		s->fmt_km = kom_calloc(void*, opt->n_thread);
+		for (i = 0; i < opt->n_thread; ++i)
+			s->fmt_km[i] = opt->flag & MB_F_NO_KALLOC? 0 : km_init();
+		kt_for(opt->n_thread, worker_for_format, in, s->n_sb);
+		for (i = 0; i < opt->n_thread; ++i)
+			if (s->fmt_km[i]) km_destroy(s->fmt_km[i]);
+		free(s->fmt_km);
 		return in;
-    } else if (step == 2) { // step 2: output
-		void *km = 0;
+    } else if (step == 2) { // step 2: output (pure ordered I/O; text was built in step 1)
         step_t *s = (step_t*)in;
-		const mb_idx_t *idx = p->idx;
-		kstring_t out = {0,0,0};
 		int64_t tot_len = 0;
 
 		for (i = 0; i < opt->n_thread; ++i)
 			mb_tbuf_destroy(s->tbuf[i]);
 		free(s->tbuf);
-		if (!(opt->flag & MB_F_NO_KALLOC)) km = km_init();
 
+		// write the prebuilt per-superbatch buffers in input order, then free them
+		for (i = 0; i < s->n_sb; ++i) {
+			if (s->str[i].l) fwrite(s->str[i].s, 1, s->str[i].l, s->p->fp_out);
+			free(s->str[i].s);
+		}
+		free(s->str);
+
+		// free per-read mapping results and sequences
 		for (k = 0; k < s->n_frag; ++k) {
 			int32_t seg_st = s->seg_off[k], seg_en = s->seg_off[k] + s->seg_cnt[k];
-			out.l = 0;
 			for (i = seg_st; i < seg_en; ++i) {
-				mb_bseq1_t *t = &s->seq[i];
-				int32_t mate_qlen = 0; // mate's l_seq for MC:Z; 0 suppresses MC/MQ
-				if (seg_en - seg_st > 1) {
-					int32_t mate_idx = i != seg_en - 1? i + 1 : seg_st; // wrap around if i is the last segment
-					mate_qlen = s->seq[mate_idx].l_seq;
-				}
-				tot_len += t->l_seq;
-				if (s->n_hit[i] > 0) { // the query has at least one hit
-					int32_t n_sec = 0;
-					for (j = 0; j < s->n_hit[i]; ++j) {
-						const mb_hit_t *h = &s->hit[i][j];
-						if (h->parent == h->id || n_sec < opt->out_n)
-							mb_format(km, &out, idx->l2b, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], j, opt->flag, i - seg_st, mate_qlen);
-						n_sec += (h->parent != h->id);
-					}
-				} else if (!(opt->flag & MB_F_NO_UNMAP)) {
-					mb_format(km, &out, idx->l2b, t, seg_en - seg_st, &s->n_hit[seg_st], &s->hit[seg_st], -1, opt->flag, i - seg_st, mate_qlen);
-				}
-			}
-			fwrite(out.s, 1, out.l, s->p->fp_out);
-			for (i = seg_st; i < seg_en; ++i) {
+				tot_len += s->seq[i].l_seq;
 				for (j = 0; j < s->n_hit[i]; ++j) free(s->hit[i][j].p);
 				free(s->hit[i]);
 				free(s->seq[i].seq); free(s->seq[i].name);
@@ -233,9 +266,7 @@ static void *worker_pipeline(void *shared, int step, void *in)
 			}
 		}
 
-		free(out.s);
 		free(s->hit); free(s->n_hit); free(s->seq);
-		km_destroy(km);
 		if (kom_verbose >= 3)
 			fprintf(stderr, "[M::%s::%.3f*%.2f] mapped %ld bp in %ld sequences\n", __func__, kom_realtime(), kom_percent_cpu(), (long)tot_len, (long)s->n_seq);
 		free(s);


### PR DESCRIPTION
Mapping output is currently formatted serially in step 2: the single output thread calls `mb_format()` for every read and `fwrite()`s the text. Once mapping is fast (many threads, short reads), the mapping threads finish and idle while that one thread formats and writes everything, so the output thread becomes the wall.

This builds the SAM/PAF text in step 1 instead, in a `kt_for()` over superbatches. Each worker formats its superbatch into its own `kstring_t` from a per-thread kalloc pool, so the pass is lock-free and adds no per-superbatch allocator churn. Step 2 then just `fwrite()`s the prebuilt buffers in input order. Output is byte-identical and in the same order as before; I checked this on paired-end, interleaved, and single-thread runs.

The effect is confined to the high-thread regime, where the output thread is the bottleneck. On a 96-vCPU Graviton4 (c8g.24xlarge), gcc 15, aligning about 20M paired-end reads (2x150 bp) against GRCh38, median of 5 runs:

| threads | wall (master) | eff | wall (this PR) | eff | speedup |
|--------:|--------------:|----:|---------------:|----:|--------:|
| 96 | 36.4s | 0.74 | 30.2s | 0.90 | 1.21x |
| 80 | 37.1s | 0.88 | 35.2s | 0.93 | 1.05x |
| 64 | 43.1s | 0.94 | 42.7s | 0.95 | 1.01x |
| 48 | 55.8s | 0.97 | 55.5s | 0.98 | 1.00x |
| 32 | 81.3s | 1.00 | 81.3s | 1.00 | 1.00x |

`eff` is parallel efficiency relative to the 32-thread point, `(wall_32 / wall_N) * (32 / N)`, so 1.00 is ideal scaling from 32 threads. On master, efficiency falls to 0.74 at 96 threads because the output thread cannot keep up; with this change 96 threads run at 0.90. Below ~64 threads the output thread is no longer the limit and the two are within run-to-run noise. This matters for whole-genome runs on large many-core machines, where it shows up as wall time (and, on spot instances, exposure to preemption) rather than throughput per core.

The second commit pre-sizes each superbatch's output buffer from its base count instead of growing it from zero. The geometric growth left about 1.7x the final text in rounded-up scratch (260 MB allocated for 153 MB of text on a default `-K` chunk); reserving up front drops that to ~171 MB and removes the realloc chain. Working-set memory is otherwise unchanged -- the buffered text is one chunk's worth, bounded by `-K`, not the whole file -- and total peak RSS is index-dominated and does not move measurably.

This is independent of #32, which makes the per-record formatter (`mb_format`) itself cheaper; the two touch different files and compose.

If a per-stage timing breakdown (read/decompress, mapping, formatting, write) would be more convincing than the efficiency curve, I can add one -- it shows the format+write time dropping out of the serial tail directly.
