### PR TITLE
fixed a heap overflow in mb_bwt_init_from_raw on empty input

### DIFF
--- a/bwt.c
+++ b/bwt.c
@@ -73,6 +73,7 @@ mb_bwt_t *mb_bwt_init_from_raw(int is_byte, const void *raw_, uint64_t len, uint
 	bwt->seq_len = len;
 	bwt->data_len = mb_bwt_data_len(len);
 	bwt->data = kom_calloc(uint64_t, bwt->data_len);
+	if (len == 0) return bwt; // nothing to encode; avoid the last-block overflow
 
 	memset(c, 0, 32);
 	for (i = k = 0; i < len; ++i) {


### PR DESCRIPTION
`mb_bwt_init_from_raw` crashes when called with `len == 0`. `mb_bwt_data_len(0)` allocates only 4 `uint64_t` (one occurrence block, no BWT block), but the encode loop is skipped and the final "last block" code still writes two 32-byte blocks (`x[]` and `c[]`, 8 `uint64_t`) into that buffer — a 32-byte heap overflow that also reads an uninitialized `x[]`. AddressSanitizer reports `heap-buffer-overflow` at the second `memcpy`; under `-DNDEBUG` it is a live heap smash, since the `assert(k == data_len)` that would otherwise catch it (8 != 4) is compiled out.

The fix returns the freshly allocated, zero-filled `bwt` as soon as `len == 0`. `mb_bwt_init()` already zeroes `L2[]` and `data[]`, and for an empty sequence the base counts are genuinely zero, so the empty BWT is well-formed (`seq_len = 0`, `data_len = 4`, `L2[4] = 0`) and every rank/occ/SA consumer handles it — their loops are bounded by `seq_len` and the valid `k` range collapses to `{0, 1}`.

This is reachable from the CLI: `minibwa index` on an empty reference (an empty file, or records with empty sequences) makes `index.c` derive `len` from `tot_len == 0` and call `mb_bwt_init_from_raw(..., 0, ...)`. Confirmed: an asan build crashes at `bwt.c:99` on all three of an empty file, `>chr1\n\n`, and two empty records; the patched build indexes all three cleanly.

Verified with `make asan=1`. Default build and the chrM end-to-end map (2013 records) are unchanged.
