### PR TITLE
harden the l2b_pos2cid binary search against a latent infinite loop

### DIFF
--- a/l2bit.c
+++ b/l2bit.c
@@ -9,16 +9,17 @@ KSEQ_INIT(gzFile, gzread);
 static int64_t l2b_pos2cid(const l2b_t *l2b, int64_t s, int64_t len, int64_t *cst)
 {
 	int64_t lo = 0, hi = l2b->n_ctg, mid;
-	const l2b_ctg_t *ctg = 0;
 	while (lo < hi) {
+		const l2b_ctg_t *ctg;
 		mid = (lo + hi) / 2;
 		ctg = &l2b->ctg[mid];
-		if (ctg->off <= s && s < ctg->off + ctg->len) break;
-		else if (s < ctg->off) hi = mid;
-		else lo = mid;
+		if (ctg->off <= s && s < ctg->off + ctg->len) {
+			*cst = s - ctg->off;
+			return s + len <= ctg->off + ctg->len? mid : -1;
+		} else if (s < ctg->off) hi = mid;
+		else lo = mid + 1;
 	}
-	*cst = s - ctg->off;
-	return s + len <= ctg->off + ctg->len? mid : -1;
+	return -1; // s is in no contig
 }
 
 int64_t l2b_intv2cid(const l2b_t *l2b, uint64_t st, uint64_t en, int64_t *cst, int *rev)


### PR DESCRIPTION
**Defensive hardening; not a live bug.** No current caller can reach it: `l2b_intv2cid` and `l2b_intv2cid_meth` both clamp `s` into `[0, tot_len)` before calling `l2b_pos2cid`, so `s` always falls inside a contig today. This fixes the search for any future caller that passes an out-of-range `s`.

The defect: `l2b_pos2cid` binary-searches the contigs but updates the lower bound with `lo = mid` instead of `lo = mid + 1`. Once the window narrows to `hi == lo + 1`, `mid == lo` and the `else` branch leaves `lo` unchanged, so the loop never terminates for an `s` past the last contig. The two sibling binary searches in `l2b_getambi` already use `lo = mid + 1`.

The fix computes `*cst` and the return value inside the loop on a hit and returns `-1` after the loop, mirroring `l2b_getambi`. Besides the non-termination, this drops the old post-loop dereference of `ctg`, which also read `ctg == 0` when `n_ctg == 0`.

Verified with a direct reproducer (`#include "l2bit.c"`, `alarm()`-guarded): it hangs (SIGALRM) on an out-of-range `s` before the fix and returns `-1` after, with the in-range, boundary-spanning, and exact-fill cases all correct. All callers also check the returned cid `< 0` before reading `*cst`. Default build and the chrM end-to-end map (2013 records) are unchanged.
