### PR TITLE
Fix: restore .l2b after low-memory meth index build

### DIFF
--- a/index.c
+++ b/index.c
@@ -315,6 +315,7 @@ int main_index(int argc, char *argv[])
 		if (is_meth) {
 			l2b_save_pac_meth(fn_l2b, l2b, 1);
 			mb_bwtgen(fn_l2b, fn_meth_bwt, block_size);
+			l2b_save(fn_l2b, l2b); // restore the real .l2b; the meth pac above overwrote it (cf. the regular pass)
 			bwt = mb_bwt_load_raw(fn_meth_bwt);
 			mb_bwt_gen_sa(bwt, sa_bit);
 			mb_bwt_save(fn_meth_bwt, bwt);


### PR DESCRIPTION
In the low-memory (-l/bwtgen) path, building the methylation index calls l2b_save_pac_meth() which overwrites the .l2b file with the 4x meth pac to feed bwtgen. The regular pass does the same with l2b_save_pac() but restores the real .l2b afterward via l2b_save(); the meth branch was missing the restore.

As a result, 'index --meth -l' left .l2b as raw pac data (no L2B_MAGIC header), so the resulting index failed to load for mapping.

This PR adds the matching l2b_save() call after the meth bwtgen, mirroring the regular pass. The non-low-mem (libsais) path is unaffected, and the non-meth paths are also unaffected.