### PR TITLE
Fix typo in help menu usage string

### DIFF
--- a/main.c
+++ b/main.c
@@ -23,7 +23,7 @@ int main_bench(int argc, char *argv[]);
 
 static int usage(FILE *fp, int is_long)
 {
-	fprintf(fp, "Usage: minibwt <command> <arguments>\n");
+	fprintf(fp, "Usage: minibwa <command> <arguments>\n");
 	fprintf(fp, "Commands:\n");
 	if (is_long) {
 		fprintf(fp, "  General:\n");


### PR DESCRIPTION
The command usage string in the help menu was referred to as "minibwt" instead of "minibwa".