### PR TITLE
-x sr is silently identical to -x adap

### DIFF
--- a/options.c
+++ b/options.c
@@ -47,7 +47,6 @@ static void mb_opt_reset(mb_opt_t *opt)
 
 void mb_opt_init(mb_opt_t *opt)
 {
-	mb_opt_reset(opt);
 	mb_opt_preset(opt, "adap");
 }
 
@@ -56,9 +55,8 @@ int mb_opt_preset(mb_opt_t *opt, const char *preset)
 	mb_opt_reset(opt);
 	if (strcmp(preset, "sr") == 0 || strcmp(preset, "adap") == 0) {
 		opt->flag |= MB_F_PE;
-		if (strcmp(preset, "adap") == 0) opt->flag |= MB_F_ADAP;
+		if (strcmp(preset, "adap") == 0) opt->flag |= MB_F_ADAP; // the only difference between sr and adap
 		opt->min_dp_max = 30;
-		opt->flag |= MB_F_ADAP;
 		opt->bw = 100;
 		opt->max_gap = 100;
 		opt->zdrop = 80;
@@ -70,7 +68,6 @@ int mb_opt_preset(mb_opt_t *opt, const char *preset)
 		opt->mb_size = 100000000;
 	} else if (strcmp(preset, "lr") == 0) {
 		opt->flag |= MB_F_LONG;
-		opt->flag &= ~MB_F_PE;
 		opt->min_dp_max = 50;
 		opt->bw = 500;
 		opt->max_gap = 5000;


### PR DESCRIPTION
`-x sr` gives identical output to `-x adap`. `mb_opt_preset` sets `MB_F_ADAP` unconditionally two lines below the gated set that r234 added when it separated the two presets, so both end up at flag `0x4048` and `sr` is unreachable. The man page has `adap` as `-xsr --adap=yes`, which is not currently true.

Deleting the stray line restores `sr`. Two no-ops go with it: `mb_opt_preset` resets `opt` on entry, so the `mb_opt_reset` in `mb_opt_init` and the `~MB_F_PE` in the `lr` branch do nothing. Drop those two if you prefer the one-line fix.

On 1M HG002 WGS pairs, `-x adap` is byte-identical to before; `-x sr` moves 0.11% of pairs, 69% of them at MAPQ <= 1.

If you meant the two presets to stay identical, the gated line should go instead and the man page needs correcting.
