### PR TITLE
exit code was always 0 even on error

### DIFF
--- a/main.c
+++ b/main.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
 			fprintf(stderr, " %s", argv[i]);
 		fprintf(stderr, "\n[M::%s] Real time: %.3f sec; CPU: %.3f sec; Peak RSS: %.3f GB\n", __func__, kom_realtime(), kom_cputime(), kom_peakrss() / 1024.0 / 1024.0 / 1024.0);
 	}
-	return 0;
+	return ret;
 }
 
 static int usage_getref(FILE *fp)


### PR DESCRIPTION
`main()` collects each subcommand's return value into `ret` and already uses it — the verbose stats block a few lines above is guarded by `ret == 0` — but then returns 0 unconditionally, so every failure exits successfully.

```
                            before   after
minibwa map --bogus-opt        0       1
minibwa map -x bogus-preset    0       1
minibwa map (normal)           0       0
```

This matters for scripts and pipelines: a mistyped option prints `[ERROR] unknown option in "..."`, maps nothing, and still looks like success to `set -e` or a workflow engine.

Only the propagation is fixed here. Detection is unchanged, and two nearby gaps are left alone: `mem` doesn't diagnose unknown long options at all (it passes no long-option table to `ketopt`), and a missing index still aborts with SIGABRT rather than exiting.
